### PR TITLE
Relocate ansible_python_interpreter.

### DIFF
--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -4,8 +4,6 @@
   strategy: free
   become: true
   force_handlers: true
-  vars:
-    ansible_python_interpreter: /usr/libexec/platform-python
   tasks:
     - name: Perform OS upgrade
       ansible.builtin.import_role:

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -46,6 +46,11 @@
     post_reboot_delay: 60
     reboot_timeout: 43200
 
+# Ansible discovers /usr/bin/python on RHEL 7, then on RHEL 8 it is no longer available.
+- name: Set python interpreter to /usr/bin/python3 since /usr/bin/python is no longer available
+  ansible.builtin.set_fact:
+    ansible_python_interpreter: /usr/bin/python3
+
 - name: Wait for leapp_resume run once service to no longer exist
   ansible.builtin.service:
     name: leapp_resume


### PR DESCRIPTION
To allow RHEL 6 -> 7 to work.