### PR TITLE
Cleanup RHEL 6 to 7 upgrade.

### DIFF
--- a/roles/upgrade/tasks/redhat-upgrade-tool-post-upgrade.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-post-upgrade.yml
@@ -13,15 +13,9 @@
 - name: Include check-for-old-packages.yml
   ansible.builtin.include_tasks: check-for-old-packages.yml
 
-# TODO: Remove enough old el6 packages that yum update can complete successfully.
-
-# TODO: Remove el6 kernels?
-
 # TODO: Update GRUB Legacy to GRUB 2.
 
 - name: Include update-and-reboot.yml
   ansible.builtin.include_tasks: update-and-reboot.yml
-
-# TODO: If Samba is installed run testparm on /etc/samba/smb.conf?
 
 ...

--- a/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
@@ -41,7 +41,7 @@
 
 # TODO: Add support for non-RHSM.
 
-# TODO: Remove --cleanup-post option and more selectively cleanup old packages in post.
+# --cleanup-post removes Red Hat signed RHEL 6 packages and in theory should be safe.
 - name: Run redhat-upgrade-tool
   ansible.builtin.shell: >
     set -o pipefail;


### PR DESCRIPTION
--cleanup-post is OK to keep.
Omit samba check, that's an app issue.
EL6 packages and kernels are cleaned up by --cleanup-post.