### PR TITLE
Fix leapp cleanup

### DIFF
--- a/roles/analysis/tasks/main.yml
+++ b/roles/analysis/tasks/main.yml
@@ -18,6 +18,9 @@
   ansible.builtin.copy:
     content: "{{ ansible_facts | ansible.builtin.combine({'ansible_local': {}}) }}"
     dest: /etc/ansible/facts.d/pre_ripu.fact
+    mode: '0644'
+    owner: root
+    group: root
 
 - name: Include tasks for preupg assistant analysis
   ansible.builtin.include_tasks: analysis-preupg.yml

--- a/roles/upgrade/tasks/leapp-post-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade.yml
@@ -40,6 +40,8 @@
 - name: Remove leapp related packages
   ansible.builtin.package:
     name:
+      - leapp
+      - leapp-deps
       - leapp-deps-el{{ ansible_distribution_major_version }}
       - leapp-repository-deps-el{{ ansible_distribution_major_version }}
       - kernel-workaround


### PR DESCRIPTION
When upgrading from 7.9 to 8.8, some leapp packages for 7.9 remained causing the subsequent yum update to fail.