### PR TITLE
Post upgrade validate major os version

### DIFF
--- a/roles/analysis/tasks/main.yml
+++ b/roles/analysis/tasks/main.yml
@@ -18,6 +18,9 @@
   ansible.builtin.copy:
     content: "{{ ansible_facts | ansible.builtin.combine({'ansible_local': {}}) }}"
     dest: /etc/ansible/facts.d/pre_ripu.fact
+    mode: '0644'
+    owner: root
+    group: root
 
 - name: Include tasks for preupg assistant analysis
   ansible.builtin.include_tasks: analysis-preupg.yml

--- a/roles/upgrade/defaults/main.yml
+++ b/roles/upgrade/defaults/main.yml
@@ -5,10 +5,6 @@ leapp_upgrade_type: disconnected
 
 leapp_upgrade_opts: "{{ '--no-rhsm' if leapp_upgrade_type == 'connected' else '' }}"
 
-rhel_6_upgrade_dest_version: '7.9'
-rhel_7_upgrade_dest_version: '8.8'
-rhel_8_upgrade_dest_version: '9.2'
-
 leapp_repos_enabled: []
 # leapp_repos_enabled:
 #   - satellite-client-6-for-rhel-{{ ansible_distribution_major_version | int + 1 }}-x86_64-rpms

--- a/roles/upgrade/tasks/leapp-upgrade-validation.yml
+++ b/roles/upgrade/tasks/leapp-upgrade-validation.yml
@@ -14,7 +14,7 @@
       {{
       (migration_results_json.activities |
       selectattr('activity', 'match', 'upgrade') |
-      selectattr('target_os', 'match', 'Red Hat Enterprise Linux ' + rhel_dest_version) |
+      selectattr('target_os', 'match', 'Red Hat Enterprise Linux ' + ansible_distribution_major_version) |
       selectattr('env.LEAPP_CURRENT_PHASE', 'match', 'FirstBoot'))[0].success
       }}
 

--- a/roles/upgrade/tasks/upgrade-validation.yml
+++ b/roles/upgrade/tasks/upgrade-validation.yml
@@ -2,33 +2,20 @@
 - name: Collect updated facts
   ansible.builtin.setup:
 
-- name: Determine rhel_dest_version from rhel 6
+- name: Determine rhel_dest_major_version
   ansible.builtin.set_fact:
-    rhel_dest_version: "{{ rhel_6_upgrade_dest_version }}"
-  when: ansible_facts.ansible_local.pre_ripu.distribution_major_version == '6'
+    rhel_dest_major_version: "{{ ((ansible_facts.ansible_local.pre_ripu.distribution_major_version | int) + 1) | string }}"
 
-- name: Determine rhel_dest_version from rhel 7
-  ansible.builtin.set_fact:
-    rhel_dest_version: "{{ rhel_7_upgrade_dest_version }}"
-  when: ansible_facts.ansible_local.pre_ripu.distribution_major_version == '7'
-
-- name: Determine rhel_dest_version from rhel 8
-  ansible.builtin.set_fact:
-    rhel_dest_version: "{{ rhel_8_upgrade_dest_version }}"
-  when: ansible_facts.ansible_local.pre_ripu.distribution_major_version == '8'
-
-- name: Validate current OS version
+- name: Validate current OS major version
   ansible.builtin.assert:
-    that: ansible_distribution_version == rhel_dest_version
-    fail_msg: Expected leapp destination OS version {{ rhel_dest_version }} but OS version is {{ ansible_distribution_version }}.
+    that: ansible_distribution_major_version == rhel_dest_major_version
+    fail_msg: Expected leapp destination OS major version {{ rhel_dest_major_version }} but OS major version is {{ ansible_distribution_major_version }}.
     success_msg: Current OS version is {{ ansible_distribution_version }}.
 
 - name: Validate running kernel matches OS version
-  vars:
-    expected_distribution_major_version: "{{ (ansible_facts.ansible_local.pre_ripu.distribution_major_version | int + 1) | string }}"
   ansible.builtin.assert:
-    that: "'el{{ expected_distribution_major_version }}' in ansible_kernel"
-    fail_msg: Kernel version {{ ansible_kernel }} does not match expected OS version el{{ expected_distribution_major_version }}.
+    that: "'el{{ rhel_dest_major_version }}' in ansible_kernel"
+    fail_msg: Kernel version {{ ansible_kernel }} does not match expected OS major version el{{ rhel_dest_major_version }}.
     success_msg: Current kernel version is {{ ansible_kernel }}.
 
 - name: Include leapp post upgrade validation


### PR DESCRIPTION
Since this will be a moving target and cause maintenance issues, checking the major version ensures that the upgrade was successful assuming the correct repositories were provided.