### PR TITLE
Remove python2-leapp package with other leapp package cleanup.

### DIFF
--- a/roles/upgrade/tasks/leapp-post-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade.yml
@@ -45,6 +45,7 @@
       - leapp-deps-el{{ ansible_distribution_major_version }}
       - leapp-repository-deps-el{{ ansible_distribution_major_version }}
       - kernel-workaround
+      - python2-leapp
     state: absent
   register: result
 


### PR DESCRIPTION
7.9 -> 8.8 packages are not being cleaned they way 7.9 -> 8.6 packages were.