### PR TITLE
WIP - Capture and review non-rhel versioned packages 

### DIFF
--- a/roles/analysis/tasks/main.yml
+++ b/roles/analysis/tasks/main.yml
@@ -22,6 +22,31 @@
     owner: root
     group: root
 
+- name: Capture a list of non-rhel versioned packages
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail;
+      rpm -qa | grep -ve '[\.|+]el{{ ansible_distribution_major_version }}' |
+      grep -vE '^(gpg-pubkey|libmodulemd|katello-ca-consumer)' |
+      sort
+  register: unsigned_packages_pre
+  changed_when: false
+  failed_when:
+    - unsigned_packages_pre.rc != 0
+    - unsigned_packages_pre.stderr != ""
+
+- name: Create fact with the non-rhel versioned packages list
+  ansible.builtin.set_fact:
+    non_rhel_packages: "{{ unsigned_packages_pre.stdout_lines }}"
+
+- name: Capture the list of non-rhel versioned packages in a separate fact file
+  ansible.builtin.copy:
+    content: "{{ non_rhel_packages }}"
+    dest: /etc/ansible/facts.d/non_rhel_packages.fact
+    mode: '0644'
+    owner: root
+    group: root
+
 - name: Include tasks for preupg assistant analysis
   ansible.builtin.include_tasks: analysis-preupg.yml
   when: ansible_distribution_major_version|int == 6

--- a/roles/upgrade/tasks/check-for-old-packages.yml
+++ b/roles/upgrade/tasks/check-for-old-packages.yml
@@ -8,24 +8,48 @@
       grep -ve '[\.|+]el{{ ansible_distribution_major_version }}' |
       grep -vE '^(gpg-pubkey|libmodulemd|katello-ca-consumer)' |
       sort
-  register: previous_version_packages
+  register: unsigned_packages_post
   changed_when: false
   failed_when:
-    - previous_version_packages.rc != 0
-    - previous_version_packages.stderr != ""
+    - unsigned_packages_post.rc != 0
+    - unsigned_packages_post.stderr != ""
+
+- name: Set a fact that lists the old packages and packages not versioned by rhel release
+  ansible.builtin.set_fact:
+    unsigned_packages_post: "{{ unsigned_packages_post.stdout_lines }}"
+    cacheable: true
+
+- name: Diff the list of current un-versioned packages and the previous list of un-versioned packages and set fact for missing packages
+  ansible.builtin.set_fact:
+    missing_non_rhel_packages: "{{ ansible_facts.ansible_local.non_rhel_packages | difference(unsigned_packages_post) }}"
+
+- name: Display warning message if there are any missing non-rhel versioned packages from the pre-upgrade
+  ansible.builtin.debug:
+    msg:
+      - "Warning!! There are non-rhel packages that were removed during the upgrade. Please review the list of missing packages"
+      - "{{ missing_non_rhel_packages }}"
+  when: missing_non_rhel_packages | length >= 1
+
+- name: Save list of missing packages for future use/review
+  ansible.builtin.copy:
+    content: "{{ missing_non_rhel_packages }}"
+    dest: /etc/ansible/facts.d/missing_packages.fact
+    mode: '0644'
+    owner: root
+    group: root
 
 - name: Display results of search for old packages and packages not versioned by rhel release
   ansible.builtin.debug:
-    msg: "{{ previous_version_packages.stdout_lines }}"
+    msg: "{{ unsigned_packages_post.stdout_lines }}"
 
-- name: Search for packages associated with old packages and packages not versioned by rhel release
+- name: Search for packages from previous os release, packages not versioned by rhel release and all dependent packages
   ansible.builtin.package:
-    name: "{{ previous_version_packages.stdout_lines }}"
+    name: "{{ unsigned_packages_post.stdout_lines }}"
     state: absent
   check_mode: true
   register: search_packages_result
 
-- name: Display results of search for packages associated with old packages and packages not versioned by rhel release
+- name: Display results of the search for packages from the previous os release, packages not versioned by rhel release and all dependent packages
   ansible.builtin.debug:
     msg: "{{ search_packages_result.changes.removed | default(search_packages_result.results) | default([]) | regex_replace('Removed: ', '') }}"
 


### PR DESCRIPTION
roles/analysis
  - Updated main.yml to capture a list of non-rhel versioned packages and save the list for comparison after the upgrade roles/upgrade
  - Updated check-for-old-packages.yml to capture a post-upgrade list of non-rhel versioned packages and compare them to the pre-upgrade list.
    - Prints a warning message and list of missing packages (if any packages were removed during the upgrade).