### PR TITLE
Test from latest RHEL 9 control node

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -95,22 +95,25 @@ jobs:
         run: echo "supported_platforms=${{ steps.supported_platforms.outputs.supported_platforms }}"
 
   testing-farm:
-    name: ${{ matrix.platform }}/ansible-${{ matrix.ansible_version }}
+    name: ${{ matrix.compose_managed_node }}/ansible-${{ matrix.ansible_version }}
     needs: prepare_vars
     strategy:
       fail-fast: false
       matrix:
         include:
-          - platform: RHEL-7-LatestUpdated
-            ansible_version: 2.9
-          - platform: RHEL-8.10.0-Nightly
-            ansible_version: 2.16
-          - platform: RHEL-9.8.0-Nightly
-            ansible_version: 2.16
+          - ansible_version: 2.14
+            compose_controller: RHEL-9-Nightly
+            compose_managed_node: RHEL-7-LatestUpdated
+          - ansible_version: 2.16
+            compose_controller: RHEL-9-Nightly
+            compose_managed_node: RHEL-8.10.0-Nightly
+          - ansible_version: 2.17
+            compose_controller: RHEL-9-Nightly
+            compose_managed_node: RHEL-9.6.0-Nightly
     runs-on: ubuntu-latest
     env:
       ARTIFACTS_DIR_NAME: "tf_${{ github.event.repository.name }}-${{ github.event.issue.number }}_\
-        ${{ matrix.platform }}-${{ matrix.ansible_version }}_\
+        ${{ matrix.compose_managed_node }}-${{ matrix.ansible_version }}_\
         ${{ needs.prepare_vars.outputs.datetime }}/artifacts"
       ARTIFACT_TARGET_DIR: /srv/pub/alt/${{ vars.SR_LSR_USER }}/logs
     steps:
@@ -119,7 +122,7 @@ jobs:
         run: |
           printf -v DATETIME '%(%Y%m%d-%H%M%S)T' -1
           ARTIFACTS_DIR_NAME="tf_${{ github.event.repository.name }}-${{ github.event.issue.number }}_\
-          ${{ matrix.platform }}-${{ matrix.ansible_version }}_$DATETIME/artifacts"
+          ${{ matrix.compose_managed_node }}-${{ matrix.ansible_version }}_$DATETIME/artifacts"
           ARTIFACTS_TARGET_DIR=/srv/pub/alt/${{ vars.SR_LSR_USER }}/logs
           ARTIFACTS_DIR=$ARTIFACTS_TARGET_DIR/$ARTIFACTS_DIR_NAME
           ARTIFACTS_URL=https://dl.fedoraproject.org/pub/alt/${{ vars.SR_LSR_USER }}/logs/$ARTIFACTS_DIR_NAME
@@ -128,22 +131,22 @@ jobs:
           echo "ARTIFACTS_URL=$ARTIFACTS_URL" >> $GITHUB_OUTPUT
 
       - name: Set commit status as pending
-        if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
+        if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.compose_managed_node)
         uses: myrotvorets/set-commit-status-action@master
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: pending
-          context: ${{ matrix.platform }}|ansible-${{ matrix.ansible_version }}
+          context: ${{ matrix.compose_managed_node }}|ansible-${{ matrix.ansible_version }}
           description: Test started
           targetUrl: ""
 
       - name: Set commit status as success with a description that platform is skipped
-        if: "!contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)"
+        if: "!contains(needs.prepare_vars.outputs.supported_platforms, matrix.compose_managed_node)"
         uses: myrotvorets/set-commit-status-action@master
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: success
-          context: ${{ matrix.platform }}|ansible-${{ matrix.ansible_version }}
+          context: ${{ matrix.compose_managed_node }}|ansible-${{ matrix.ansible_version }}
           description: The role does not support this platform. Skipping.
           targetUrl: ""
 
@@ -159,7 +162,7 @@ jobs:
 
       - name: Run test in testing farm
         uses: sclorg/testing-farm-as-github-action@v4
-        if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
+        if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.compose_managed_node)
         with:
           git_ref: main
           pipeline_settings: '{ "type": "tmt-multihost" }'
@@ -174,10 +177,14 @@ jobs:
             SR_LSR_USER=${{ vars.SR_LSR_USER }};\
             SR_TEST_LOCAL_CHANGES=false;\
             SR_ARTIFACTS_URL=${{ steps.set_vars.outputs.ARTIFACTS_URL }}"
+          context:
+            COMPOSE_CONTROLLER: ${{ matrix.compose_controller }}
+            COMPOSE_MANAGED_NODE: ${{ matrix.compose_managed_node }}
+            initiator: testing-farm
           # Note that LINUXSYSTEMROLES_SSH_KEY must be single-line, TF doesn't read multi-line variables fine.
           secrets: "SR_LSR_DOMAIN=${{ secrets.SR_LSR_DOMAIN }};\
             SR_LSR_SSH_KEY=${{ secrets.SR_LSR_SSH_KEY }}"
-          compose: ${{ matrix.platform }}
+          compose: ${{ matrix.compose_managed_node }}
           # There are two blockers for using public ranch:
           # 1. multihost is not supported in public https://github.com/teemtee/tmt/issues/2620
           # 2. Security issue that leaks long secrets - Jira TFT-2698
@@ -187,10 +194,10 @@ jobs:
 
       - name: Set final commit status
         uses: myrotvorets/set-commit-status-action@master
-        if: always() && contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
+        if: always() && contains(needs.prepare_vars.outputs.supported_platforms, matrix.compose_managed_node)
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: ${{ job.status }}
-          context: ${{ matrix.platform }}|ansible-${{ matrix.ansible_version }}
+          context: ${{ matrix.compose_managed_node }}|ansible-${{ matrix.ansible_version }}
           description: Test finished
           targetUrl: ${{ steps.set_vars.outputs.ARTIFACTS_URL }}

--- a/plans/README-plans.md
+++ b/plans/README-plans.md
@@ -23,19 +23,17 @@ You can run tests locally with the `tmt try` cli or remotely in Testing Farm.
 1. Install `tmt` as described in [Installation](https://tmt.readthedocs.io/en/stable/stories/install.html).
 2. Change to the role repository directory.
 3. Optionally, modify `plans/test_playbooks_parallel.fmf` to modify variables to suit your requirements.
-    1. Due to [issue #3138](https://github.com/teemtee/tmt/issues/3138), keep a single managed node.
-    2. By default, `SR_TFT_DEBUG=true` is set to run from the changes that you have locally in the roles code, the CI overwrites it.
-4. Enter `tmt try -p /plans/test_playbooks <platform>`.
-    This command identifies the `plans/test_playbooks_parallel.fmf` plan and provisions local VMs, a control node and a managed node.
-    `<platform>` can be rhel9@minute
+    Due to [issue #3138](https://github.com/teemtee/tmt/issues/3138), keep a single managed node.
+4. Enter `tmt -c COMPOSE_MANAGED_NODE=<platform> try -p /plans/test_playbooks <platform>`.
+    This command identifies the `plans/test_playbooks_parallel.fmf` plan and provisions VMs in 1minutetip, and runs tests defined in the plan.
+    `<platform>` is a platform from 1minutetip list, can be e.g. rhel8.
 
 ### Running in Testing Farm
 
 1. Install `testing-farm` as described in [Installation](https://gitlab.com/testing-farm/cli/-/blob/main/README.adoc#user-content-installation).
 2. Change to the role repository directory.
 3. If you want to run tests with edits in your branch, you need to commit and push changes first to some branch.
-4. You can uncomment "Inject your ssh public key to test systems" discover step in the plan if you want to troubleshoot tests by SSHing into test systems in Testing Farm.
-5. Enter `testing-farm request`.
+4. Enter `testing-farm request`.
     Edit to your needs.
 
     ```bash

--- a/plans/test_playbooks.fmf
+++ b/plans/test_playbooks.fmf
@@ -1,15 +1,40 @@
 summary: Test Ansible playbooks from control node against managed nodes
 tag: test_playbook
-provision:
-  - name: control-node1
-    role: control_node
-    # TF uses `how: artemis`, tmt try uses `how: virtual`. No need to define `how`
-    # `connection: system` is for `how: virtual` to make VMs get a real IP to configure ssh easily
-    # This setting is ignored on artemis so we can keep it
-    connection: system
-  - name: managed-node1
-    role: managed_node
-    connection: system
+adjust:
+  - when: initiator != testing-farm
+    provision+:
+      - name: control-node01
+        role: control_node
+        how: minute
+        image: rhel9
+      - name: managed-node01
+        role: managed_node
+        how: minute
+        image: ${COMPOSE_MANAGED_NODE}
+  - when: initiator == testing-farm
+    provision+:
+      - name: control-node01
+        role: control_node
+        how: artemis
+        image: ${COMPOSE_CONTROLLER}
+        # In case we want to use different arch, we can use the following var:
+        # arch: ${ARCH_CONTROLLER}
+        arch: x86_64
+      - name: managed-node01
+        role: managed_node
+        how: artemis
+        image: ${COMPOSE_MANAGED_NODE}
+        arch: x86_64
+      - name: managed-node02
+        role: managed_node
+        how: artemis
+        image: ${COMPOSE_MANAGED_NODE}
+        arch: x86_64
+      - name: managed-node03
+        role: managed_node
+        how: artemis
+        image: ${COMPOSE_MANAGED_NODE}
+        arch: x86_64
 environment:
     SR_ANSIBLE_VER: 2.17
     SR_REPO_NAME: ""


### PR DESCRIPTION
* Previously, CI was using the same platform for control and managed nodes. This doesn't work because the role only supports RHEL 9 as a control node. The RPM for the role will be released to RHEL 9 only.
* This PR fixes this by always assigning the controller to be the latest
* RHEL 9 released, and the managed node to be the platform defined from matrix.
* Locally, the controller is also latest rhel 9, and the managed node compose should be defined with `-c COMPOSE_MANAGED_NODE=<platform>`.