### PR TITLE
Fix running tests in tf and locally

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -189,14 +189,13 @@ jobs:
             SR_TEST_LOCAL_CHANGES=false;\
             SR_LSR_USER=${{ vars.SR_LSR_USER }};\
             SR_TEST_LOCAL_CHANGES=false;\
-            SR_ARTIFACTS_URL=${{ steps.set_vars.outputs.ARTIFACTS_URL }}"
-          tmt_context: "COMPOSE_CONTROLLER=${{ matrix.compose_controller }};\
+            COMPOSE_CONTROLLER=${{ matrix.compose_controller }};\
             COMPOSE_MANAGED_NODE=${{ matrix.compose_managed_node }};\
-            initiator=testing-farm"
+            SR_ARTIFACTS_URL=${{ steps.set_vars.outputs.ARTIFACTS_URL }}"
+          tmt_context: "initiator=testing-farm"
           # Note that LINUXSYSTEMROLES_SSH_KEY must be single-line, TF doesn't read multi-line variables fine.
           secrets: "SR_LSR_DOMAIN=${{ secrets.SR_LSR_DOMAIN }};\
             SR_LSR_SSH_KEY=${{ secrets.SR_LSR_SSH_KEY }}"
-          compose: ${{ matrix.compose_managed_node }}
           # There are two blockers for using public ranch:
           # 1. multihost is not supported in public https://github.com/teemtee/tmt/issues/2620
           # 2. Security issue that leaks long secrets - Jira TFT-2698

--- a/plans/README-plans.md
+++ b/plans/README-plans.md
@@ -26,7 +26,7 @@ You can run tests locally with the `tmt try` cli or remotely in Testing Farm.
     Due to [issue #3138](https://github.com/teemtee/tmt/issues/3138), keep a single managed node.
 4. Enter `tmt -c COMPOSE_MANAGED_NODE=<platform> try -p /plans/test_playbooks`.
     This command identifies the `plans/test_playbooks_parallel.fmf` plan and provisions VMs in 1minutetip, and runs tests defined in the plan.
-    `<platform>` is a platform from 1minutetip list, can be e.g. rhel8.
+    `<platform>` can be `rhel7`, `rhel8`, or `rhel9`.
 
 ### Running in Testing Farm
 

--- a/plans/test_playbooks.fmf
+++ b/plans/test_playbooks.fmf
@@ -7,10 +7,24 @@ adjust:
         role: control_node
         how: minute
         image: rhel9
+  - when: initiator is not defined and COMPOSE_MANAGED_NODE=rhel7
+    provision+:
       - name: managed-node01
         role: managed_node
         how: minute
-        image: ${COMPOSE_MANAGED_NODE}
+        image: rhel7
+  - when: initiator is not defined and COMPOSE_MANAGED_NODE=rhel8
+    provision+:
+      - name: managed-node01
+        role: managed_node
+        how: minute
+        image: rhel8
+  - when: initiator is not defined and COMPOSE_MANAGED_NODE=rhel9
+    provision+:
+      - name: managed-node01
+        role: managed_node
+        how: minute
+        image: rhel-9.6
   - when: initiator == testing-farm
     provision+:
       - name: control-node01


### PR DESCRIPTION
* Allow for running locally with -c COMPOSE_MANAGED_NODE=rhelX
* Fix testing farm runs by using environment to define COMPOSE vars instead of context.
* Remove compose: from TF invocation because we define it with envs