### PR TITLE
Use tfaga action from spetrosi branch to apply fix

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -174,7 +174,10 @@ jobs:
           TF_API_KEY_RH: ${{ secrets.TF_API_KEY_RH }}
 
       - name: Run test in testing farm
-        uses: sclorg/testing-farm-as-github-action@v4
+        # Change to the original action once this PR is merged:
+        # https://github.com/sclorg/testing-farm-as-github-action/pull/326
+        # uses: sclorg/testing-farm-as-github-action@v4
+        uses: spetrosi/testing-farm-as-github-action@compose-null-omit
         if: steps.platform_check.outputs.is_supported == 'true'
         with:
           git_ref: main


### PR DESCRIPTION
[testing-farm-as-github-action](https://github.com/sclorg/testing-farm-as-github-action) has a bug that prevents from using the action without specifying the compose.
This is our case because we specify the compose via variables.
Until the PR with the fix is merged, let's use the action from spetrosi branch.
https://github.com/sclorg/testing-farm-as-github-action/pull/326