### PR TITLE
fix undefined default variable in the parse_leapp_report role

### DIFF
--- a/roles/parse_leapp_report/defaults/main.yml
+++ b/roles/parse_leapp_report/defaults/main.yml
@@ -2,5 +2,6 @@
 # defaults file for parse_leapp_report
 result_filename_prefix: /var/log/leapp/leapp-report
 result_filename_json: "{{ result_filename_prefix }}.json"
+result_filename_txt: "{{ result_filename_prefix }}.txt"
 result_fact_cacheable: false
 ...

--- a/roles/parse_leapp_report/tasks/main.yml
+++ b/roles/parse_leapp_report/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Collect human readable report results
   ansible.builtin.slurp:
-    src: "{{ result_filename }}"
+    src: "{{ result_filename_txt }}"
   register: results_txt
 
 - name: Collect JSON report results
@@ -35,14 +35,14 @@
   vars:
     high_filter: "{{ '|Risk Factor: high' if leapp_high_sev_as_inhibitors | default(false, true) | bool else '' }}"
   ansible.builtin.command:
-    cmd: awk '/\(inhibitor\){{ high_filter }}/,/^-------/' {{ result_filename }}
+    cmd: awk '/\(inhibitor\){{ high_filter }}/,/^-------/' {{ result_filename_txt }}
   register: results_inhibitors
   changed_when: false
   failed_when: false
 
 - name: Collect high errors
   ansible.builtin.command:
-    cmd: awk '/high \(error\)/,/^-------/' {{ result_filename }}
+    cmd: awk '/high \(error\)/,/^-------/' {{ result_filename_txt }}
   register: results_errors
   changed_when: false
   failed_when: false


### PR DESCRIPTION
Tests were failing due to an undefined variable in `parse_leapp_report` role.