### PR TITLE
Replace internal repository URLs with GitHub secrets

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -194,6 +194,13 @@ jobs:
             SR_TEST_LOCAL_CHANGES=false;\
             COMPOSE_CONTROLLER=${{ matrix.compose_controller }};\
             COMPOSE_MANAGED_NODE=${{ matrix.compose_managed_node }};\
+            RHEL_7_9_EXTRAS_REPO_URL=${{ secrets.RHEL_7_9_EXTRAS_REPO_URL }};\
+            RHEL_8_10_BASEOS_REPO_URL=${{ secrets.RHEL_8_10_BASEOS_REPO_URL }};\
+            RHEL_8_10_APPSTREAM_REPO_URL=${{ secrets.RHEL_8_10_APPSTREAM_REPO_URL }};\
+            RHEL_9_6_BASEOS_REPO_URL=${{ secrets.RHEL_9_6_BASEOS_REPO_URL }};\
+            RHEL_9_6_APPSTREAM_REPO_URL=${{ secrets.RHEL_9_6_APPSTREAM_REPO_URL }};\
+            RHEL_10_0_BASEOS_REPO_URL=${{ secrets.RHEL_10_0_BASEOS_REPO_URL }};\
+            RHEL_10_0_APPSTREAM_REPO_URL=${{ secrets.RHEL_10_0_APPSTREAM_REPO_URL }};\
             SR_ARTIFACTS_URL=${{ steps.set_vars.outputs.ARTIFACTS_URL }}"
           tmt_context: "initiator=testing-farm"
           # Note that LINUXSYSTEMROLES_SSH_KEY must be single-line, TF doesn't read multi-line variables fine.

--- a/tests/tests_upgrade_custom_7to8.yml
+++ b/tests/tests_upgrade_custom_7to8.yml
@@ -3,24 +3,25 @@
   hosts: all
   vars_files:
     - vars/common_upgrade_vars.yml
+    - vars/repo_urls.yml
   vars:
     leapp_upgrade_type: custom
     leapp_upgrade_opts: "--no-rhsm"
-    local_repos_pre_leapp:
+    local_repos_pre_leapp: # Install leapp
       - name: rhel-7-server-extras-rpms
         description: RHEL 7 Server Extras
-        baseurl: "https://download.eng.brq.redhat.com/rhel-7/nightly/EXTRAS-7/latest-EXTRAS-7.9-RHEL-7/compose/Server/x86_64/os/"
+        baseurl: "{{ repo_urls.rhel7.extras.url }}"
         file: rhel7_extras
         state: present
     local_repos_leapp:
       - name: rhel-8-for-x86_64-baseos-rpms
         description: BaseOS for x86_64
-        baseurl: "{{ repo_urls.rhel8.base_url }}/BaseOS/x86_64/os/"
+        baseurl: "{{ repo_urls.rhel8.baseos.url }}"
         file: /etc/leapp/files/leapp_upgrade_repositories
         state: present
       - name: rhel-8-for-x86_64-appstream-rpms
         description: AppStream for x86_64
-        baseurl: "{{ repo_urls.rhel8.base_url }}/AppStream/x86_64/os/"
+        baseurl: "{{ repo_urls.rhel8.appstream.url }}"
         file: /etc/leapp/files/leapp_upgrade_repositories
         state: present
     title_map: "{{ common_title_map }}"

--- a/tests/tests_upgrade_custom_8to9.yml
+++ b/tests/tests_upgrade_custom_8to9.yml
@@ -3,27 +3,19 @@
   hosts: all
   vars_files:
     - vars/common_upgrade_vars.yml
+    - vars/repo_urls.yml
   vars:
     leapp_upgrade_type: custom
     leapp_upgrade_opts: "--no-rhsm"
-    # local_repos_pre_leapp:
-    #   - name: rhel-8-for-x86_64-baseos-rpms
-    #     description: BaseOS for x86_64
-    #     baseurl: "{{ repo_urls.rhel8.base_url }}/BaseOS/x86_64/os/"
-    #     state: present
-    #   - name: rhel-8-for-x86_64-appstream-rpms
-    #     description: AppStream for x86_64
-    #     baseurl: "{{ repo_urls.rhel8.base_url }}/AppStream/x86_64/os/"
-    #     state: present
     local_repos_leapp:
       - name: rhel-9-for-x86_64-baseos-rpms
         description: BaseOS for x86_64
-        baseurl: "{{ repo_urls.rhel9.base_url }}/BaseOS/x86_64/os/"
+        baseurl: "{{ repo_urls.rhel9.baseos.url }}"
         file: /etc/leapp/files/leapp_upgrade_repositories
         state: present
       - name: rhel-9-for-x86_64-appstream-rpms
         description: AppStream for x86_64
-        baseurl: "{{ repo_urls.rhel9.base_url }}/AppStream/x86_64/os/"
+        baseurl: "{{ repo_urls.rhel9.appstream.url }}"
         file: /etc/leapp/files/leapp_upgrade_repositories
         state: present
     title_map: "{{ common_title_map }}"

--- a/tests/tests_upgrade_custom_9to10.yml
+++ b/tests/tests_upgrade_custom_9to10.yml
@@ -3,27 +3,19 @@
   hosts: all
   vars_files:
     - vars/common_upgrade_vars.yml
+    - vars/repo_urls.yml
   vars:
     leapp_upgrade_type: custom
     leapp_upgrade_opts: "--no-rhsm"
-    local_repos_pre_leapp:
-      - name: rhel-9-for-x86_64-baseos-rpms
-        description: BaseOS for x86_64
-        baseurl: "{{ repo_urls.rhel9.base_url }}/BaseOS/x86_64/os/"
-        state: present
-      - name: rhel-9-for-x86_64-appstream-rpms
-        description: AppStream for x86_64
-        baseurl: "{{ repo_urls.rhel9.base_url }}/AppStream/x86_64/os/"
-        state: present
     local_repos_leapp:
       - name: rhel-10-for-x86_64-baseos-rpms
         description: BaseOS for x86_64
-        baseurl: "{{ repo_urls.rhel10.base_url }}/BaseOS/x86_64/os/"
+        baseurl: "{{ repo_urls.rhel10.baseos.url }}"
         file: /etc/leapp/files/leapp_upgrade_repositories
         state: present
       - name: rhel-10-for-x86_64-appstream-rpms
         description: AppStream for x86_64
-        baseurl: "{{ repo_urls.rhel10.base_url }}/AppStream/x86_64/os/"
+        baseurl: "{{ repo_urls.rhel10.appstream.url }}"
         file: /etc/leapp/files/leapp_upgrade_repositories
         state: present
     title_map: "{{ common_title_map }}"

--- a/tests/tmt/test_playbooks/test_playbooks.sh
+++ b/tests/tmt/test_playbooks/test_playbooks.sh
@@ -144,6 +144,15 @@ rlJournalStart
             fi
         fi
 
+        repo_vars_file="$coll_path/tests/vars/repo_urls.yml"
+        [ -n "$RHEL_7_9_EXTRAS_REPO_URL" ] && sed -i "s|__RHEL_7_9_EXTRAS_REPO_URL__|$RHEL_7_9_EXTRAS_REPO_URL|g" "$repo_vars_file"
+        [ -n "$RHEL_8_10_BASEOS_REPO_URL" ] && sed -i "s|__RHEL_8_10_BASEOS_REPO_URL__|$RHEL_8_10_BASEOS_REPO_URL|g" "$repo_vars_file"
+        [ -n "$RHEL_8_10_APPSTREAM_REPO_URL" ] && sed -i "s|__RHEL_8_10_APPSTREAM_REPO_URL__|$RHEL_8_10_APPSTREAM_REPO_URL|g" "$repo_vars_file"
+        [ -n "$RHEL_9_6_BASEOS_REPO_URL" ] && sed -i "s|__RHEL_9_6_BASEOS_REPO_URL__|$RHEL_9_6_BASEOS_REPO_URL|g" "$repo_vars_file"
+        [ -n "$RHEL_9_6_APPSTREAM_REPO_URL" ] && sed -i "s|__RHEL_9_6_APPSTREAM_REPO_URL__|$RHEL_9_6_APPSTREAM_REPO_URL|g" "$repo_vars_file"
+        [ -n "$RHEL_10_0_BASEOS_REPO_URL" ] && sed -i "s|__RHEL_10_0_BASEOS_REPO_URL__|$RHEL_10_0_BASEOS_REPO_URL|g" "$repo_vars_file"
+        [ -n "$RHEL_10_0_APPSTREAM_REPO_URL" ] && sed -i "s|__RHEL_10_0_APPSTREAM_REPO_URL__|$RHEL_10_0_APPSTREAM_REPO_URL|g" "$repo_vars_file"
+
         rlWaitForCmd "ansible-galaxy collection install -r $coll_path/meta/collection-requirements.yml -vv" -m 5
 
         # if lsrVaultRequired "$legacy_test_path"; then

--- a/tests/vars/common_upgrade_vars.yml
+++ b/tests/vars/common_upgrade_vars.yml
@@ -29,16 +29,4 @@ common_title_map:
 common_leapp_answerfile: |
   [remove_pam_pkcs11_module_check]
   confirm = True
-
-# Repository URL templates
-repo_urls:
-  rhel8:
-    base_url: "http://download.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.10/compose"
-    latest_version: "8.10"
-  rhel9:
-    base_url: "http://download.eng.brq.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose"
-    latest_version: "9.6"
-  rhel10:
-    base_url: "http://download.eng.brq.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose"
-    latest_version: "10.0"
 ...

--- a/tests/vars/repo_urls.yml
+++ b/tests/vars/repo_urls.yml
@@ -1,0 +1,24 @@
+---
+# Repository URL templates
+# Note: These placeholders are replaced by environment variables
+# See tests/tmt/test_playbooks/test_playbooks.sh for the substitution logic
+repo_urls:
+  rhel7:
+    extras:
+      url: "__RHEL_7_9_EXTRAS_REPO_URL__"
+  rhel8:
+    baseos:
+      url: "__RHEL_8_10_BASEOS_REPO_URL__"
+    appstream:
+      url: "__RHEL_8_10_APPSTREAM_REPO_URL__"
+  rhel9:
+    baseos:
+      url: "__RHEL_9_6_BASEOS_REPO_URL__"
+    appstream:
+      url: "__RHEL_9_6_APPSTREAM_REPO_URL__"
+  rhel10:
+    baseos:
+      url: "__RHEL_10_0_BASEOS_REPO_URL__"
+    appstream:
+      url: "__RHEL_10_0_APPSTREAM_REPO_URL__"
+...


### PR DESCRIPTION
 Hide internal repository URL's

    * Separate common repo URL's into Appstream and BaseOS repo URL's
    * Put repo URL's placeholders into separate vars file,
    * Make action tft.yml take those repo URL's from GitHub secrets
    * Add substitution of URL placeholders for environment variables in test
      playbooks
    * Remove non-needed/commented-out repositories

No beakerlib or tmt funcion was suitable for this so I decided to do it through github secrets.

Jira: RHELMISC-20528


