### PR TITLE
Fix upgrade from RHEL 8 to 9

### DIFF
--- a/changelogs/fragments/fix-8-9-upgrade.yml
+++ b/changelogs/fragments/fix-8-9-upgrade.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - Remove outdated (pre-upgrade) bootloader kernel entries.
+  - Do not output information about included custom repositories to avoid exposing URLs.
+
+...

--- a/roles/common/tasks/custom_local_repos.yml
+++ b/roles/common/tasks/custom_local_repos.yml
@@ -21,5 +21,6 @@
     group: root
     mode: "0644"
   loop: "{{ __repos }}"
+  no_log: true
 
 ...

--- a/roles/upgrade/tasks/leapp-post-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade.yml
@@ -41,6 +41,33 @@
         state: absent
       loop: "{{ old_kernels.files }}"
 
+# Grep for title matching RHEL, then get kernel path from 4 lines above
+- name: >-
+    leapp-post-upgrade | Find kernel paths for outdated RHEL
+    {{ ansible_facts.ansible_local.pre_ripu.distribution_major_version }}
+  ansible.builtin.shell: >-
+    set -o pipefail;
+    export PATH={{ os_path }};
+    grubby --info=ALL | grep -E "^title=.* {{
+    ansible_facts.ansible_local.pre_ripu.distribution_major_version
+    }}\.[0-9]+ " -B 4 | grep "^kernel"
+    | sed -n 's/.*kernel="\([^"]*\)".*/\1/p' || echo ""
+  register: leapp_upgrade_outdated_kernels
+  when: remove_old_rhel_packages
+  changed_when: false
+
+- name: leapp-post-upgrade | Debug kernel paths for outdated RHEL
+  ansible.builtin.debug:
+    var: leapp_upgrade_outdated_kernels.stdout_lines
+
+- name: leapp-post-upgrade | Remove outdated RHEL kernels from bootloader using grubby
+  ansible.builtin.command: grubby --remove-kernel={{ item | quote }}
+  loop: "{{ leapp_upgrade_outdated_kernels.stdout_lines }}"
+  when:
+    - remove_old_rhel_packages
+    - leapp_upgrade_outdated_kernels.stdout | length > 0
+  changed_when: true
+
 - name: leapp-post-upgrade | Include handle-old-packages.yml
   ansible.builtin.include_tasks: handle-old-packages.yml
 
@@ -145,32 +172,6 @@
   when: post_upgrade_update | bool
 
 # TODO: Validate RHEL OS versions again?
-
-# Only found in RHEL 7 to 8 documentation
-- name: leapp-post-upgrade | Old kernels have been removed from the bootloader entry for RHEL 7 to 8
-  ansible.builtin.shell: |
-    set -o pipefail;
-    export PATH={{ os_path }};
-    grubby --info=ALL | grep "\.el7" || echo "Old kernels are not present in the bootloader."
-  register: grubby_check
-  when: ansible_facts.ansible_local.pre_ripu.distribution_major_version | int == 7
-  changed_when: false
-  failed_when: grubby_check.stdout != 'Old kernels are not present in the bootloader.'
-
-# Only found in RHEL 8 to 9 documentation (maybe 9 to 10).
-# This fails on RHEL 8 to 9 if old kernel packages are not removed.
-# For RHEL 7 to 8, in my testing, no RHEL 7 kernels remain after leapp.
-- name: leapp-post-upgrade | No previous RHEL kernels are present in /boot/loader/entry files
-  ansible.builtin.shell: |
-    set -o pipefail;
-    export PATH={{ os_path }};
-    grep -r ".el{{ ansible_facts.ansible_local.pre_ripu.distribution_major_version }}" "/boot/loader/entries/" || echo "Everything seems ok."
-  register: boot_loader_entries
-  when:
-    - remove_old_rhel_packages # This will fail if the old kernel packages weren't removed.
-    - ansible_facts.ansible_local.pre_ripu.distribution_major_version | int >= 8
-  changed_when: false
-  failed_when: boot_loader_entries.stdout != 'Everything seems ok.'
 
 - name: leapp-post-upgrade | Include tasks for leapp post upgrade selinux
   ansible.builtin.include_tasks: leapp-post-upgrade-selinux.yml

--- a/tests/tasks/common_upgrade_tasks.yml
+++ b/tests/tasks/common_upgrade_tasks.yml
@@ -41,17 +41,6 @@
 - name: common_upgrade_tasks | Flush handlers
   ansible.builtin.meta: flush_handlers
 
-- name: common_upgrade_tasks | Reinstall linux-firmware via dnf (remove)
-  ansible.builtin.command: dnf remove -y linux-firmware
-  changed_when: false
-
-- name: common_upgrade_tasks | Reinstall linux-firmware via dnf (install)
-  ansible.builtin.command: dnf install -y linux-firmware
-  changed_when: false
-
-- name: common_upgrade_tasks | Flush handlers
-  ansible.builtin.meta: flush_handlers
-
 - name: common_upgrade_tasks | Run analysis after remediation
   ansible.builtin.include_role:
     name: infra.leapp.analysis

--- a/tests/tests_upgrade_custom_8to9.yml
+++ b/tests/tests_upgrade_custom_8to9.yml
@@ -42,7 +42,7 @@
         - name: Assert that the system has been upgraded to RHEL 9
           ansible.builtin.assert:
             that:
-              - ansible_distribution not ['CentOS', 'RedHat']
+              - ansible_distribution in ['CentOS', 'RedHat']
               - ansible_distribution_major_version == "9"
             fail_msg: "System was not upgraded to RHEL 9. Current OS: {{ ansible_distribution }} {{ ansible_distribution_version }}"
             success_msg: "System successfully upgraded to RHEL 9"


### PR DESCRIPTION
* Remove outdated (pre-upgrade) bootloader kernel entries. Previously, these were removed only by removing associated RPMs, this change finds kernels that remain and removes them directly with `grubby`.
This could be a bug in systemd-udev, usually kernels remain after removing associated RPMs. To be investigated and reported, but until this is fixed in RHEL, the role should do the workaround applied.
* Do not output information about included custom repositories to avoid exposing URLs
* Remove the workaround to reinstall linux-firmware, it was caused by incorrectly set up repositories. Instead of using the latest z-stream repository for RHEL 9, the CI was using outdated RHEL-9.6.0 repositories.