### PR TITLE
refactor: Refactor remediations - extract common code into role main - do not use fail/rescue

### DIFF
--- a/changelogs/fragments/refactor_remediations.yml
+++ b/changelogs/fragments/refactor_remediations.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Refactor remediations - extract common code into remediation main.yml - use conditionals/blocks instead of fail/rescue for flow control.
+...

--- a/roles/remediate/tasks/leapp_cgroups-v1_enabled.yml
+++ b/roles/remediate/tasks/leapp_cgroups-v1_enabled.yml
@@ -1,71 +1,42 @@
 ---
+- name: leapp_cgroups-v1_enabled | Continue when leapp report is missing
+  ansible.builtin.debug:
+    msg: "Leapp report missing. Skipping this task."
+  when: leapp_report_missing | default(false)
+
 - name: leapp_cgroups-v1_enabled | Disable cgroups-v1 in favor of the new version cgroups-v2
   vars:
-    leapp_report_location: /var/log/leapp/leapp-report.json
     leapp_inhibitor_title: cgroups-v1 enabled on the system
+    remediation_matches: "{{ leapp_report_data.entries | selectattr('title', 'match', leapp_inhibitor_title) |
+      map(attribute='detail.remediations') | flatten | list }}"
+    leapp_inhibitor_remediation: "{{ remediation_matches | selectattr('type', 'eq', 'command') | first
+      if remediation_matches | length > 0 else {} }}"
   when:
+    - not leapp_report_missing | default(false)
     - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version|int == 9
+    - ansible_distribution_major_version | int == 9
   block:
-    - name: leapp_cgroups-v1_enabled | Check that the leapp-report.json exists
-      ansible.builtin.stat:
-        path: "{{ leapp_report_location }}"
-      register: leapp_report_stat
-
-    - name: leapp_cgroups-v1_enabled | End remediation early if the leapp report does not exist
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: true
-      when:
-        - not leapp_report_stat.stat.exists
-        - leapp_report_stat.stat.size <= 0
-
-    - name: leapp_cgroups-v1_enabled | Read leapp report
-      ansible.builtin.slurp:
-        src: "{{ leapp_report_location }}"
-      register: leapp_report
-
-    - name: leapp_cgroups-v1_enabled | Find the inhibitor entry in the leapp report and extract the remediation command
-      # The remediation executes recommended command from the report since it
-      # is generated with specific kernel arguments that need to be disabled
-      # based on the system's configuration.
-      vars:
-        leapp_report_data: "{{ leapp_report.content | b64decode | from_json }}"
-      ansible.builtin.set_fact:
-        leapp_inhibitor_remediation: "{{ item.detail.remediations | selectattr('type', 'eq', 'command') | first }}"
-      loop: "{{ leapp_report_data.entries }}"
-      when:
-        - item.title == leapp_inhibitor_title
-        - item.detail.remediations | selectattr('type', 'eq', 'command') | list | length > 0
-
     - name: leapp_cgroups-v1_enabled | End remediation if a matching entry was not found in the leapp report
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: true
-      when:
-        - leapp_inhibitor_remediation is not defined
-        - leapp_inhibitor_remediation.context | length <= 0
-
-    - name: leapp_cgroups-v1_enabled | Show the remediation command
       ansible.builtin.debug:
-        msg: "{{ leapp_inhibitor_remediation.context | join(' ') }}"
+        msg: "No matching entry found in leapp report. Skipping this task."
+      when: leapp_inhibitor_remediation | length == 0
 
-    - name: leapp_cgroups-v1_enabled | Update the kernel arguments to disable the cgroups-v1 in favor of cgroups-v2
-      ansible.builtin.command:
-        argv: "{{ leapp_inhibitor_remediation.context }}"
-      register: leapp_disable_cgroupsv1
-      changed_when: leapp_disable_cgroupsv1 is changed
-      failed_when: leapp_disable_cgroupsv1 is not success
-      notify: Reboot the system
+    - name: leapp_cgroups-v1_enabled | Process remediation
+      when: leapp_inhibitor_remediation | length > 0
+      block:
+        - name: leapp_cgroups-v1_enabled | Show the remediation command
+          ansible.builtin.debug:
+            var: leapp_inhibitor_remediation.context | join(' ')
 
-    - name: leapp_cgroups-v1_enabled | Show the remediation command result
-      ansible.builtin.debug:
-        msg: "{{ leapp_disable_cgroupsv1.stdout_lines }}"
+        - name: leapp_cgroups-v1_enabled | Update the kernel arguments to disable the cgroups-v1 in favor of cgroups-v2
+          ansible.builtin.command:
+            argv: "{{ leapp_inhibitor_remediation.context }}"
+          register: leapp_disable_cgroupsv1
+          changed_when: leapp_disable_cgroupsv1 is success
+          notify: Reboot the system
 
-  rescue:
-    - name: leapp_cgroups-v1_enabled | Continue when leapp report is missing
-      ansible.builtin.debug:
-        msg: "Leapp report missing or did not contain any matches. Skipping this task."
-      when: leapp_report_missing | d(false)
+        - name: leapp_cgroups-v1_enabled | Show the remediation command result
+          ansible.builtin.debug:
+            msg: leapp_disable_cgroupsv1.stdout_lines
 
 ...

--- a/roles/remediate/tasks/leapp_corrupted_grubenv_file.yml
+++ b/roles/remediate/tasks/leapp_corrupted_grubenv_file.yml
@@ -1,76 +1,56 @@
 ---
+- name: leapp_corrupted_grubenv_file | Continue when leapp report is missing
+  ansible.builtin.debug:
+    msg: "Leapp report missing. Skipping this task."
+  when: leapp_report_missing | default(false)
+
 - name: leapp_corrupted_grubenv_file | Detected a corrupted grubenv file
+  when: not leapp_report_missing | default(false)
   vars:
     entry_title: Detected a corrupted grubenv file
-    leapp_report_location: /var/log/leapp/leapp-report.json
+    remediation_matches: "{{ leapp_report_data.entries | selectattr('title', 'match', entry_title) |
+      map(attribute='detail.remediations') | flatten | list }}"
+    hints: "{{ remediation_matches | selectattr('type', 'eq', 'hint') | list
+      if remediation_matches | length > 0 else [] }}"
+    hint: "{{ hints | first if hints | length > 0 else {} }}"
   block:
-    - name: leapp_corrupted_grubenv_file | Check that the leapp-report.json exists
-      ansible.builtin.stat:
-        path: "{{ leapp_report_location }}"
-      register: leapp_report_stat
-
-    - name: leapp_corrupted_grubenv_file | End play if no leapp report exists
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      when: leapp_report_stat.stat.exists is false
-      failed_when: leapp_report_stat.stat.exists is false
-
-    - name: leapp_corrupted_grubenv_file | Read leapp report
-      ansible.builtin.slurp:
-        src: "{{ leapp_report_location }}"
-      register: leappreport
-
-    - name: leapp_corrupted_grubenv_file | Parse leapp report to json
-      ansible.builtin.set_fact:
-        leappreportdata: "{{ leappreport.content | b64decode | from_json }}"
-
-    - name: leapp_corrupted_grubenv_file | Find matching entries
-      ansible.builtin.set_fact:
-        hint: "{{ item.detail.remediations | selectattr('type', 'eq', 'hint') | first }}"
-      loop: "{{ leappreportdata.entries }}"
-      when: item.title is match(entry_title) and (item.detail.remediations | selectattr('type', 'eq', 'hint') | length > 0)
-
     - name: leapp_corrupted_grubenv_file | End execution of playbook if no entry found in leapp report
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: hint is not defined
-
-    - name: leapp_corrupted_grubenv_file | Extract file(s) using regex
-      ansible.builtin.set_fact:
-        files_grub: "{{ hint.context | regex_findall('Delete (.+?) file', '\\1') | first | split(',') | map('trim') }}"
-
-    - name: leapp_corrupted_grubenv_file | Backup file(s)
-      ansible.builtin.copy:
-        src: "{{ item }}"
-        dest: "{{ item }}.backup"
-        mode: "0644"
-      with_items: "{{ files_grub }}"
-
-    - name: leapp_corrupted_grubenv_file | Find grub.cfg file
-      ansible.builtin.command: find /boot -name 'grub.cfg'
-      register: grub_cfg_path
-      changed_when: grub_cfg_path.rc == 0
-
-    - name: leapp_corrupted_grubenv_file | Backup grub.cfg file
-      ansible.builtin.copy:
-        src: "{{ grub_cfg_path.stdout }}"
-        dest: "{{ grub_cfg_path.stdout }}.backup"
-        mode: "0644"
-
-    - name: leapp_corrupted_grubenv_file | Delete file(s)
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: absent
-      with_items: "{{ files_grub }}"
-
-    - name: leapp_corrupted_grubenv_file | Regenerate grub config
-      ansible.builtin.command: grub2-mkconfig -o {{ grub_cfg_path.stdout }}
-      register: grub_mkconfig
-      changed_when: grub_mkconfig.rc == 0
-
-  rescue:
-    - name: leapp_corrupted_grubenv_file | Continue when leapp report is missing
       ansible.builtin.debug:
-        msg: "Leapp report missing or did not contain any matches. Skipping this task."
-      when: leapp_report_missing is defined and leapp_report_missing is true
+        msg: "No matching entry found in leapp report. Skipping this task."
+      when: hint | length == 0
+
+    - name: leapp_corrupted_grubenv_file | Process remediation
+      when: hint | length > 0
+      vars:
+        files_grub: "{{ hint.context | regex_findall('Delete (.+?) file', '\\1') | first | split(',') | map('trim') }}"
+      block:
+        - name: leapp_corrupted_grubenv_file | Backup file(s)
+          ansible.builtin.copy:
+            src: "{{ item }}"
+            dest: "{{ item }}.backup"
+            mode: "0644"
+          with_items: "{{ files_grub }}"
+
+        - name: leapp_corrupted_grubenv_file | Find grub.cfg file
+          ansible.builtin.command: find /boot -name 'grub.cfg'
+          register: grub_cfg_path
+          changed_when: grub_cfg_path is success
+
+        - name: leapp_corrupted_grubenv_file | Backup grub.cfg file
+          ansible.builtin.copy:
+            src: "{{ grub_cfg_path.stdout }}"
+            dest: "{{ grub_cfg_path.stdout }}.backup"
+            mode: "0644"
+
+        - name: leapp_corrupted_grubenv_file | Delete file(s)
+          ansible.builtin.file:
+            path: "{{ item }}"
+            state: absent
+          with_items: "{{ files_grub }}"
+
+        - name: leapp_corrupted_grubenv_file | Regenerate grub config
+          ansible.builtin.command: grub2-mkconfig -o {{ grub_cfg_path.stdout }}
+          register: grub_mkconfig
+          changed_when: grub_mkconfig is success
+
 ...

--- a/roles/remediate/tasks/leapp_custom_network_scripts_detected.yml
+++ b/roles/remediate/tasks/leapp_custom_network_scripts_detected.yml
@@ -1,6 +1,8 @@
 ---
 - name: leapp_custom_network_scripts_detected | Move custom network-scripts to NetworkManager dispatcher scripts
-  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 8
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version | int == 8
   block:
     - name: leapp_custom_network_scripts_detected | Check if pre up script exists
       ansible.builtin.stat:
@@ -12,84 +14,80 @@
         path: /sbin/ifdown-pre-local
       register: pre_down
 
-    # If neither script exists, fail out and do not create unnecessary directories
-    - name: leapp_custom_network_scripts_detected | Skip playbook if no custom scripts are found
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      when: pre_down.stat.exists is false and pre_up.stat.exists is false
-      failed_when: pre_down.stat.exists is false and pre_up.stat.exists is false
-
-    - name: leapp_custom_network_scripts_detected | Create /opt/network-scripts/ directory if it does not exist
-      ansible.builtin.file:
-        path: /opt/network-scripts/
-        state: directory
-        mode: "0755"
-
-    - name: leapp_custom_network_scripts_detected | Move scripts in /sbin to /opt/network-scripts/, end playbook if this fails
-      ansible.builtin.command: mv /sbin/if*-local /opt/network-scripts/
-      register: move_scripts
-      when: pre_up.stat.exists or pre_down.stat.exists
-      changed_when: move_scripts.rc == 0
-
-    - name: leapp_custom_network_scripts_detected | Create /etc/NetworkManager/dispatcher.d/20-if-local
-      ansible.builtin.copy:
-        dest: /etc/NetworkManager/dispatcher.d/20-if-local
-        mode: +x
-        content: >
-          #!/bin/bash -eu
-
-          test -n "$DEVICE_IFACE" || exit 0
-
-          run() {
-              test -x "$1" || exit 0
-              "$1" "$DEVICE_IFACE"
-          }
-
-          case "$2" in
-              "up")
-                  run /opt/network-scripts/ifup-local
-                  ;;
-              "pre-up")
-                  run /opt/network-scripts/ifup-pre-local
-                  ;;
-              "down")
-                  run /opt/network-scripts/ifdown-local
-                  ;;
-              "pre-down")
-                  run /opt/network-scripts/ifdown-pre-local
-                  ;;
-          esac
-
-    - name: leapp_custom_network_scripts_detected | Set permissions on /etc/NetworkManager/dispatcher.d/20-if-local
-      ansible.builtin.file:
-        path: /etc/NetworkManager/dispatcher.d/20-if-local
-        owner: root
-        group: root
-        mode: +x
-
-    - name: leapp_custom_network_scripts_detected | Restore SELinux context on /etc/NetworkManager/dispatcher.d/20-if-local
-      ansible.builtin.command: restorecon -v /etc/NetworkManager/dispatcher.d/20-if-local
-      register: restorecon
-      changed_when: restorecon.rc == 0
-
-    - name: leapp_custom_network_scripts_detected | If pre up script exists, create symbolic link
-      ansible.builtin.file:
-        src: /etc/NetworkManager/dispatcher.d/20-if-local
-        dest: /etc/NetworkManager/dispatcher.d/pre-up.d/20-if-local
-        state: link
-      when: pre_up.stat.exists
-
-    - name: leapp_custom_network_scripts_detected | If pre down script exists, create symbolic link
-      ansible.builtin.file:
-        src: /etc/NetworkManager/dispatcher.d/20-if-local
-        dest: /etc/NetworkManager/dispatcher.d/pre-down.d/20-if-local
-        state: link
-      when: pre_down.stat.exists
-
-  rescue:
     - name: leapp_custom_network_scripts_detected | Continue when no custom scripts are found
       ansible.builtin.debug:
         msg: "No custom network scripts detected. Skipping this task."
-      when: leapp_custom_scripts_missing is defined and leapp_custom_scripts_missing is true
+      when:
+        - not pre_down.stat.exists
+        - not pre_up.stat.exists
+
+    - name: leapp_custom_network_scripts_detected | Process remediation
+      when: pre_up.stat.exists or pre_down.stat.exists
+      block:
+        - name: leapp_custom_network_scripts_detected | Create /opt/network-scripts/ directory if it does not exist
+          ansible.builtin.file:
+            path: /opt/network-scripts/
+            state: directory
+            mode: "0755"
+
+        - name: leapp_custom_network_scripts_detected | Move scripts in /sbin to /opt/network-scripts/, end playbook if this fails
+          ansible.builtin.command: mv /sbin/if*-local /opt/network-scripts/
+          register: move_scripts
+          changed_when: move_scripts is success
+
+        - name: leapp_custom_network_scripts_detected | Create /etc/NetworkManager/dispatcher.d/20-if-local
+          ansible.builtin.copy:
+            dest: /etc/NetworkManager/dispatcher.d/20-if-local
+            mode: +x
+            content: >
+              #!/bin/bash -eu
+
+              test -n "$DEVICE_IFACE" || exit 0
+
+              run() {
+                  test -x "$1" || exit 0
+                  "$1" "$DEVICE_IFACE"
+              }
+
+              case "$2" in
+                  "up")
+                      run /opt/network-scripts/ifup-local
+                      ;;
+                  "pre-up")
+                      run /opt/network-scripts/ifup-pre-local
+                      ;;
+                  "down")
+                      run /opt/network-scripts/ifdown-local
+                      ;;
+                  "pre-down")
+                      run /opt/network-scripts/ifdown-pre-local
+                      ;;
+              esac
+
+        - name: leapp_custom_network_scripts_detected | Set permissions on /etc/NetworkManager/dispatcher.d/20-if-local
+          ansible.builtin.file:
+            path: /etc/NetworkManager/dispatcher.d/20-if-local
+            owner: root
+            group: root
+            mode: +x
+
+        - name: leapp_custom_network_scripts_detected | Restore SELinux context on /etc/NetworkManager/dispatcher.d/20-if-local
+          ansible.builtin.command: restorecon -v /etc/NetworkManager/dispatcher.d/20-if-local
+          register: restorecon
+          changed_when: restorecon is success
+
+        - name: leapp_custom_network_scripts_detected | If pre up script exists, create symbolic link
+          ansible.builtin.file:
+            src: /etc/NetworkManager/dispatcher.d/20-if-local
+            dest: /etc/NetworkManager/dispatcher.d/pre-up.d/20-if-local
+            state: link
+          when: pre_up.stat.exists
+
+        - name: leapp_custom_network_scripts_detected | If pre down script exists, create symbolic link
+          ansible.builtin.file:
+            src: /etc/NetworkManager/dispatcher.d/20-if-local
+            dest: /etc/NetworkManager/dispatcher.d/pre-down.d/20-if-local
+            state: link
+          when: pre_down.stat.exists
 
 ...

--- a/roles/remediate/tasks/leapp_deprecated_sshd_directive.yml
+++ b/roles/remediate/tasks/leapp_deprecated_sshd_directive.yml
@@ -1,55 +1,41 @@
 ---
+- name: leapp_deprecated_sshd_directive | Continue when leapp report is missing
+  ansible.builtin.debug:
+    msg: "Leapp report missing. Skipping this task."
+  when: leapp_report_missing | default(false)
+
 - name: leapp_deprecated_sshd_directive | Remove the deprecated directives from the sshd configuration.
   vars:
-    leapp_report_location: /var/log/leapp/leapp-report.json
     entry_title: A deprecated directive in the sshd configuration
-  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 8
+    remediation_matches: "{{ leapp_report_data.entries | selectattr('title', 'match', entry_title) |
+      map(attribute='detail.remediations') | flatten | list }}"
+    commands: "{{ remediation_matches | selectattr('type', 'eq', 'command') | list
+      if remediation_matches | length > 0 else [] }}"
+    remediation: "{{ commands | first if commands | length > 0 else {} }}"
+  when:
+    - not leapp_report_missing | default(false)
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version | int == 8
   block:
-    - name: leapp_deprecated_sshd_directive | Check that the leapp-report.json with remediation command exists
-      ansible.builtin.stat:
-        path: "{{ leapp_report_location }}"
-      register: leapp_report_stat
-
-    - name: leapp_deprecated_sshd_directive | End execution of playbook if leapp report does not exist (not possible to remediate)
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      when: leapp_report_stat.stat.exists is false
-      failed_when: leapp_report_stat.stat.exists is false
-
-    - name: leapp_deprecated_sshd_directive | Read leapp report
-      ansible.builtin.slurp:
-        src: "{{ leapp_report_location }}"
-      register: leappreport
-
-    - name: leapp_deprecated_sshd_directive | Parse leapp report to json
-      ansible.builtin.set_fact:
-        leappreportdata: "{{ leappreport.content | b64decode | from_json }}"
-
-    - name: leapp_deprecated_sshd_directive | Find matching entries
-      ansible.builtin.set_fact:
-        remediation: "{{ item.detail.remediations | selectattr('type', 'eq', 'command') | first }}"
-      loop: "{{ leappreportdata.entries }}"
-      when: item.title == entry_title and (item.detail.remediations | selectattr('type', 'eq', 'command') | list | length > 0)
-
     - name: leapp_deprecated_sshd_directive | End execution of playbook if no entry found in leapp report
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: remediation is not defined
-
-    - name: leapp_deprecated_sshd_directive | Output command to be executed
       ansible.builtin.debug:
-        msg: "{{ remediation.context | join(' ') }}"
+        msg: "No matching entry found in leapp report. Skipping this task."
+      when: remediation | length == 0
 
-    - name: leapp_deprecated_sshd_directive | Execute the remediation command - remove the deprecated directives from the sshd configuration
-      ansible.builtin.command: "{{ remediation.context | join(' ') }}"
-      when: remediation is defined
-      register: remediation_command_output
-      changed_when: remediation_command_output.rc == 0
+    - name: leapp_deprecated_sshd_directive | Process remediation
+      when: remediation | length > 0
+      block:
+        - name: leapp_deprecated_sshd_directive | Output command to be executed
+          ansible.builtin.debug:
+            var: remediation.context | join(' ')
 
-  rescue:
-    - name: leapp_deprecated_sshd_directive | Continue when leapp report is missing
-      ansible.builtin.debug:
-        msg: "Leapp report missing or did not contain any matches. Skipping this task."
-      when: leapp_report_missing is defined and leapp_report_missing is true
+        - name: leapp_deprecated_sshd_directive | Execute the remediation command - remove the deprecated directives from the sshd configuration
+          ansible.builtin.command:
+            argv: "{{ remediation.context }}"
+          register: remediation_command_output
+          changed_when: remediation_command_output is success
 
+        - name: leapp_deprecated_sshd_directive | Show remediation command output
+          ansible.builtin.debug:
+            var: remediation_command_output.stdout_lines
 ...

--- a/roles/remediate/tasks/leapp_firewalld_allowzonedrifting.yml
+++ b/roles/remediate/tasks/leapp_firewalld_allowzonedrifting.yml
@@ -1,6 +1,8 @@
 ---
 - name: leapp_firewalld_allowzonedrifting | Set the "AllowZoneDrifting" in firewalld.conf to "no"
-  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 8
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version | int == 8
   block:
     - name: leapp_firewalld_allowzonedrifting | Set the "AllowZoneDrifting" in firewalld.conf to "no"
       ansible.builtin.lineinfile:

--- a/roles/remediate/tasks/leapp_firewalld_unsupported_tftp_client.yml
+++ b/roles/remediate/tasks/leapp_firewalld_unsupported_tftp_client.yml
@@ -1,86 +1,64 @@
 ---
+- name: leapp_firewalld_unsupported_tftp_client | Continue when leapp report is missing
+  ansible.builtin.debug:
+    msg: "Leapp report missing. Skipping this task."
+  when: leapp_report_missing | default(false)
+
 - name: leapp_firewalld_unsupported_tftp_client | Remove unsupported tftp-client service from firewalld
   vars:
     entry_title: Firewalld Service tftp-client Is Unsupported
-    leapp_report_location: /var/log/leapp/leapp-report.json
-  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 8
+    summaries: "{{ leapp_report_data.entries | selectattr('title', 'match', entry_title) |
+      selectattr('summary', 'defined') | rejectattr('summary', 'eq', '') |
+      map(attribute='summary') | list }}"
+    summary: "{{ summaries | first if summaries | length > 0 else '' }}"
+  when:
+    - not leapp_report_missing | default(false)
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version | int == 8
   block:
-    - name: leapp_firewalld_unsupported_tftp_client | Check that the leapp-report.json exists
-      ansible.builtin.stat:
-        path: "{{ leapp_report_location }}"
-      register: leapp_report_stat
-
-    - name: leapp_firewalld_unsupported_tftp_client | End play if no leapp report exists
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      when: leapp_report_stat.stat.exists is false
-      failed_when: leapp_report_stat.stat.exists is false
-
-    - name: leapp_firewalld_unsupported_tftp_client | Read leapp report
-      ansible.builtin.slurp:
-        src: "{{ leapp_report_location }}"
-      register: leappreport
-
-    - name: leapp_firewalld_unsupported_tftp_client | Parse leapp report to json
-      ansible.builtin.set_fact:
-        leappreportdata: "{{ leappreport.content | b64decode | from_json }}"
-
-    - name: leapp_firewalld_unsupported_tftp_client | Find matching entries
-      ansible.builtin.set_fact:
-        summary: "{{ item.summary }}"
-      loop: "{{ leappreportdata.entries }}"
-      when: item.title is match(entry_title) and (item.summary | length > 0)
-
     - name: leapp_firewalld_unsupported_tftp_client | End execution of playbook if no entry found in leapp report
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: summary is not defined
+      ansible.builtin.debug:
+        msg: "No matching entry found in leapp report. Skipping this task."
+      when: summary | length == 0
 
     - name: leapp_firewalld_unsupported_tftp_client | Remove the service from zones and policies
+      when: summary | length > 0
+      vars:
+        zone_list: "{{ all_zones.stdout | split }}"
+        not_enabled_error_message: "Warning: NOT_ENABLED: tftp-client"
       block:
         - name: leapp_firewalld_unsupported_tftp_client | List all firewalld zones
           ansible.builtin.command: firewall-cmd --get-zones
           register: all_zones
           changed_when: false
 
-        - name: leapp_firewalld_unsupported_tftp_client | Split the zones into a list
-          ansible.builtin.set_fact:
-            zone_list: "{{ all_zones.stdout | split }}"
-
         - name: leapp_firewalld_unsupported_tftp_client | Remove the service from zones
-          ansible.builtin.command: firewall-cmd --permanent --zone={{ item }} --remove-service=tftp-client
+          ansible.builtin.command: firewall-cmd --permanent --zone={{ item | quote }} --remove-service=tftp-client
           loop: "{{ zone_list }}"
-          failed_when: true
-          changed_when: false
+          register: remove_from_zones
+          changed_when: not not_enabled_error_message in remove_from_zones.stderr_lines
 
         - name: leapp_firewalld_unsupported_tftp_client | Remove the service from policies
           ansible.builtin.command: firewall-cmd --permanent --remove-service=tftp-client
-          failed_when: true
-          changed_when: false
+          register: remove_from_policies
+          changed_when: not not_enabled_error_message in remove_from_policies.stderr_lines
 
-    - name: leapp_firewalld_unsupported_tftp_client | Remove the rich rules
-      block:
         - name: leapp_firewalld_unsupported_tftp_client | List all rich rules
           ansible.builtin.command: firewall-cmd --list-rich-rules
           register: rich_rules
           changed_when: false
 
         - name: leapp_firewalld_unsupported_tftp_client | Iterate through rich rules and remove tftp-client
-          ansible.builtin.command: firewall-cmd --permanent --remove-rich-rule '{{ item }}'
+          ansible.builtin.command: firewall-cmd --permanent --remove-rich-rule {{ item | quote }}
           loop: "{{ rich_rules.stdout_lines }}"
-          failed_when: true
           when: "'tftp-client' in item"
-          changed_when: true
+          register: remove_from_rich_rules
+          changed_when: "'tftp-client' in item"
 
-    - name: leapp_firewalld_unsupported_tftp_client | Reload firewalld to apply changes
-      ansible.builtin.service:
-        name: firewalld
-        state: reloaded
-
-  rescue:
-    - name: leapp_firewalld_unsupported_tftp_client | Continue when leapp report is missing
-      ansible.builtin.debug:
-        msg: "Leapp report missing or did not contain any matches. Skipping this task."
-      when: leapp_report_missing is defined and leapp_report_missing is true
+        - name: leapp_firewalld_unsupported_tftp_client | Reload firewalld to apply changes
+          ansible.builtin.service:
+            name: firewalld
+            state: reloaded
+          when: remove_from_zones is changed or remove_from_policies is changed or remove_from_rich_rules is changed
 
 ...

--- a/roles/remediate/tasks/leapp_legacy_network_configuration.yml
+++ b/roles/remediate/tasks/leapp_legacy_network_configuration.yml
@@ -1,71 +1,43 @@
 ---
+- name: leapp_legacy_network_configuration | Continue when leapp report is missing
+  ansible.builtin.debug:
+    msg: "Leapp report missing. Skipping this task."
+  when: leapp_report_missing | default(false)
+
 - name: leapp_legacy_network_configuration | Convert network manager configuration to the native keyfile format
   vars:
-    leapp_report_location: /var/log/leapp/leapp-report.json
     leapp_inhibitor_title: Legacy network configuration found
+    remediation_matches: "{{ leapp_report_data.entries | selectattr('title', 'match', leapp_inhibitor_title) |
+      map(attribute='detail.remediations') | flatten | list }}"
+    leapp_inhibitor_remediation: "{{ remediation_matches | selectattr('type', 'eq', 'command') | first
+      if remediation_matches | length > 0 else {} }}"
   when:
+    - not leapp_report_missing | default(false)
     - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version|int == 9
+    - ansible_distribution_major_version | int == 9
   block:
-    - name: leapp_legacy_network_configuration | Check that the leapp-report.json exists
-      ansible.builtin.stat:
-        path: "{{ leapp_report_location }}"
-      register: leapp_report_stat
-
-    - name: leapp_legacy_network_configuration | End remediation early if the leapp report does not exist
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: true
-      when:
-        - not leapp_report_stat.stat.exists
-        - leapp_report_stat.stat.size <= 0
-
-    - name: leapp_legacy_network_configuration | Read leapp report
-      ansible.builtin.slurp:
-        src: "{{ leapp_report_location }}"
-      register: leapp_report
-
-    - name: leapp_legacy_network_configuration | Find the inhibitor entry in the leapp report and extract the remediation command
-      # The remediation executes recommended command from the report since it
-      # is generated with specific network interface that needs to be migrated
-      # to the keyfile format.
-      vars:
-        leapp_report_data: "{{ leapp_report.content | b64decode | from_json }}"
-      ansible.builtin.set_fact:
-        leapp_inhibitor_remediation: "{{ item.detail.remediations | selectattr('type', 'eq', 'command') | first }}"
-      loop: "{{ leapp_report_data.entries }}"
-      when:
-        - item.title == leapp_inhibitor_title
-        - item.detail.remediations | selectattr('type', 'eq', 'command') | list | length > 0
-
     - name: leapp_legacy_network_configuration | End remediation if a matching entry was not found in the leapp report
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: true
+      ansible.builtin.debug:
+        msg: "No matching entry found in leapp report. Skipping this task."
+      when: leapp_inhibitor_remediation | length == 0 or leapp_inhibitor_remediation.context | length == 0
+
+    - name: leapp_legacy_network_configuration | Process remediation
       when:
-        - leapp_inhibitor_remediation is not defined
-        - leapp_inhibitor_remediation.context | length <= 0
+        - leapp_inhibitor_remediation | length > 0
+        - leapp_inhibitor_remediation.context | length > 0
+      block:
+        - name: leapp_legacy_network_configuration | Show the remediation command
+          ansible.builtin.debug:
+            var: leapp_inhibitor_remediation.context | join(' ')
 
-    - name: leapp_legacy_network_configuration | Show the remediation command
-      ansible.builtin.debug:
-        msg: "{{ leapp_inhibitor_remediation.context | join(' ') }}"
+        - name: leapp_legacy_network_configuration | Migrate the network connection configuration to the keyfile format
+          ansible.builtin.command:
+            argv: "{{ leapp_inhibitor_remediation.context }}"
+          register: leapp_legacy_network_config_migration
+          changed_when: leapp_legacy_network_config_migration is success
 
-    - name: leapp_legacy_network_configuration | Migrate the network connection configuration to the keyfile format
-      ansible.builtin.command:
-        argv: "{{ leapp_inhibitor_remediation.context }}"
-      when: leapp_inhibitor_remediation is defined
-      register: leapp_legacy_network_config_migration
-      changed_when: leapp_legacy_network_config_migration is changed
-      failed_when: leapp_legacy_network_config_migration is not success
-
-    - name: leapp_legacy_network_configuration | Show the remediation command result
-      ansible.builtin.debug:
-        msg: "{{ leapp_legacy_network_config_migration.stdout_lines }}"
-
-  rescue:
-    - name: leapp_legacy_network_configuration | Continue when leapp report is missing
-      ansible.builtin.debug:
-        msg: "Leapp report missing or did not contain any matches. Skipping this task."
-      when: leapp_report_missing | d(false)
+        - name: leapp_legacy_network_configuration | Show the remediation command result
+          ansible.builtin.debug:
+            var: leapp_legacy_network_config_migration.stdout_lines
 
 ...

--- a/roles/remediate/tasks/leapp_loaded_removed_kernel_drivers.yml
+++ b/roles/remediate/tasks/leapp_loaded_removed_kernel_drivers.yml
@@ -1,61 +1,34 @@
 ---
+- name: leapp_loaded_removed_kernel_drivers | Continue when leapp report is missing
+  ansible.builtin.debug:
+    msg: "Leapp report missing. Skipping this task."
+  when: leapp_report_missing | default(false)
+
 - name: leapp_loaded_removed_kernel_drivers | Unload kernel drivers which have been removed in next RHEL release
   vars:
-    leapp_report_location: /var/log/leapp/leapp-report.json
     entry_title_pattern: Leapp detected loaded kernel drivers which have been removed in RHEL \d+. Upgrade cannot proceed.
+    unsupported_modules: "{{ leapp_report_data.entries | selectattr('title', 'match', entry_title_pattern) |
+      selectattr('summary', 'defined') | rejectattr('summary', 'eq', '') |
+      map(attribute='summary') | flatten | map('regex_findall', '(?<=- ).*') | flatten | list }}"
+  when: not leapp_report_missing | default(false)
   block:
-    - name: leapp_loaded_removed_kernel_drivers | Check that the leapp-report.json exists
-      ansible.builtin.stat:
-        path: "{{ leapp_report_location }}"
-      register: leapp_report_stat
-
-    - name: leapp_loaded_removed_kernel_drivers | End execution of playbook if leapp report does not exist
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      when: leapp_report_stat.stat.exists is false
-      failed_when: leapp_report_stat.stat.exists is false
-
-    - name: leapp_loaded_removed_kernel_drivers | Read leapp report
-      ansible.builtin.slurp:
-        src: "{{ leapp_report_location }}"
-      register: leappreport
-
-    - name: leapp_loaded_removed_kernel_drivers | Parse leapp report to json
-      ansible.builtin.set_fact:
-        leappreportdata: "{{ leappreport.content | b64decode | from_json }}"
-
-    - name: leapp_loaded_removed_kernel_drivers | Find entry in leapp report
-      ansible.builtin.set_fact:
-        leapp_entry: "{{ item }}"
-      loop: "{{ leappreportdata.entries }}"
-      when: item.title is match(entry_title_pattern)
-
     - name: leapp_loaded_removed_kernel_drivers | End execution of playbook if no entry found in leapp report
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: leapp_entry is not defined
-
-    - name: leapp_loaded_removed_kernel_drivers | Parse summary to obtain list of modules
-      ansible.builtin.set_fact:
-        unsupported_modules: "{{ leapp_entry.summary | regex_findall('(?<=- ).*') }}"
-      when: leapp_entry is defined
-
-    - name: leapp_loaded_removed_kernel_drivers | Print unsupported modules
       ansible.builtin.debug:
-        var: unsupported_modules
+        msg: "No matching entry found in leapp report. Skipping this task."
+      when: unsupported_modules | length == 0
 
-    - name: leapp_loaded_removed_kernel_drivers | Unload unsupported modules
-      community.general.modprobe:
-        name: "{{ item }}"
-        state: absent
-      loop: "{{ unsupported_modules }}"
-      when: unsupported_modules is defined
-      changed_when: unsupported_modules is defined
+    - name: leapp_loaded_removed_kernel_drivers | Process remediation
+      when: unsupported_modules | length > 0
+      block:
+        - name: leapp_loaded_removed_kernel_drivers | Print unsupported modules
+          ansible.builtin.debug:
+            var: unsupported_modules
 
-  rescue:
-    - name: leapp_loaded_removed_kernel_drivers | Continue when leapp report is missing
-      ansible.builtin.debug:
-        msg: "Leapp report missing or did not contain any matches. Skipping this task."
-      when: leapp_report_missing is defined and leapp_report_missing is true
+        - name: leapp_loaded_removed_kernel_drivers | Unload unsupported modules
+          community.general.modprobe:
+            name: "{{ item }}"
+            state: absent
+          loop: "{{ unsupported_modules }}"
+          changed_when: unsupported_modules | length > 0
 
 ...

--- a/roles/remediate/tasks/leapp_missing_pkg.yml
+++ b/roles/remediate/tasks/leapp_missing_pkg.yml
@@ -1,50 +1,28 @@
 ---
+- name: leapp_missing_pkg | Continue when leapp report is missing
+  ansible.builtin.debug:
+    msg: "Leapp report missing. Skipping this task."
+  when: leapp_report_missing | default(false)
+
 - name: leapp_missing_pkg | Install required leapp data package on public clouds
   vars:
     entry_title_pattern: Package "[-\w]+" is missing
-    leapp_report_location: /var/log/leapp/leapp-report.json
+    remediation_matches: "{{ leapp_report_data.entries | selectattr('title', 'match', entry_title_pattern) |
+      map(attribute='detail.remediations') | flatten | list }}"
+    remediation: "{{ remediation_matches | selectattr('type', 'eq', 'command') | first
+      if remediation_matches | length > 0 else {} }}"
+  when: not leapp_report_missing | default(false)
   block:
-    - name: leapp_missing_pkg | Check that the leapp-report.json exists
-      ansible.builtin.stat:
-        path: "{{ leapp_report_location }}"
-      register: leapp_report_stat
-
-    - name: leapp_missing_pkg | End play if no leapp report exists
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      when: leapp_report_stat.stat.exists is false
-      failed_when: leapp_report_stat.stat.exists is false
-
-    - name: leapp_missing_pkg | Read leapp report
-      ansible.builtin.slurp:
-        src: "{{ leapp_report_location }}"
-      register: leappreport
-
-    - name: leapp_missing_pkg | Parse leapp report to json
-      ansible.builtin.set_fact:
-        leappreportdata: "{{ leappreport.content | b64decode | from_json }}"
-
-    - name: leapp_missing_pkg | Find matching entries
-      ansible.builtin.set_fact:
-        remediation: "{{ item.detail.remediations | selectattr('type', 'eq', 'command') | first }}"
-      loop: "{{ leappreportdata.entries }}"
-      when: item.title is match(entry_title_pattern) and (item.detail.remediations | selectattr('type', 'eq', 'command') | list | length > 0)
-
     - name: leapp_missing_pkg | End execution of playbook if no entry found in leapp report
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: remediation is not defined
+      ansible.builtin.debug:
+        msg: "No matching entry found in leapp report. Skipping this task."
+      when: remediation | length == 0
 
     - name: leapp_missing_pkg | Install the missing package via remediation command
-      ansible.builtin.command: "{{ remediation.context | join(' ') }}"
-      when: remediation is defined
+      ansible.builtin.command:
+        argv: "{{ remediation.context }}"
+      when: remediation | length > 0
       register: remediation_result
-      changed_when: remediation_result.rc == 0
-
-  rescue:
-    - name: leapp_missing_pkg | Continue when leapp report is missing
-      ansible.builtin.debug:
-        msg: "Leapp report missing or did not contain any matches. Skipping this task."
-      when: leapp_report_missing is defined and leapp_report_missing is true
+      changed_when: remediation_result is success
 
 ...

--- a/roles/remediate/tasks/leapp_missing_yum_plugins.yml
+++ b/roles/remediate/tasks/leapp_missing_yum_plugins.yml
@@ -1,49 +1,36 @@
 ---
+- name: leapp_missing_yum_plugins | Continue when leapp report is missing
+  ansible.builtin.debug:
+    msg: "Leapp report missing. Skipping this task."
+  when: leapp_report_missing | default(false)
+
 - name: leapp_missing_yum_plugins | Load required plugins
   vars:
-    leapp_report_location: /var/log/leapp/leapp-report.json
-    entry_title: Required .* plugins are not being loaded.
+    entry_title_pattern: Required .* plugins are not being loaded.
+    remediation_matches: "{{ leapp_report_data.entries | selectattr('title', 'match', entry_title_pattern) |
+      map(attribute='detail.remediations') | flatten | list }}"
+    remediation: "{{ remediation_matches | selectattr('type', 'eq', 'command') | first
+      if remediation_matches | length > 0 else {} }}"
+  when: not leapp_report_missing | default(false)
   block:
-    - name: leapp_missing_yum_plugins | Check that the leapp-report.json with remediation command exists
-      ansible.builtin.stat:
-        path: "{{ leapp_report_location }}"
-      register: leapp_report_stat
-
-    - name: leapp_missing_yum_plugins | End execution of playbook if leapp report does not exist (not possible to remediate)
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      when: leapp_report_stat.stat.exists is false
-      failed_when: leapp_report_stat.stat.exists is false
-
-    - name: leapp_missing_yum_plugins | Read leapp report
-      ansible.builtin.slurp:
-        src: "{{ leapp_report_location }}"
-      register: leappreport
-
-    - name: leapp_missing_yum_plugins | Parse leapp report to json
-      ansible.builtin.set_fact:
-        leappreportdata: "{{ leappreport.content | b64decode | from_json }}"
-
-    - name: leapp_missing_yum_plugins | Find matching entries
-      ansible.builtin.set_fact:
-        remediation: "{{ item.detail.remediations | selectattr('type', 'eq', 'command') | first }}"
-      loop: "{{ leappreportdata.entries }}"
-      when: item.title is match(entry_title) and (item.detail.remediations | selectattr('type', 'eq', 'command') | list | length > 0)
+    - name: leapp_missing_yum_plugins | End execution of playbook if no entry found in leapp report
+      ansible.builtin.debug:
+        msg: "No matching entry found in leapp report. Skipping this task."
+      when: remediation | length == 0
 
     - name: leapp_missing_yum_plugins | Output command to be executed
       ansible.builtin.debug:
-        msg: "{{ remediation.context | last }}"
+        msg: remediation.context | join(' ')
+      when: remediation | length > 0
 
     - name: leapp_missing_yum_plugins | Execute the remediation command - remove the deprecated directives from the sshd configuration
-      ansible.builtin.command: "{{ remediation.context | join(' ') }}"
-      when: remediation is defined
+      ansible.builtin.command:
+        argv: "{{ remediation.context }}"
+      when: remediation | length > 0
       register: remediation_command_output
-      changed_when: remediation_command_output.rc == 0
+      changed_when: remediation_command_output is success
 
-  rescue:
-    - name: leapp_missing_yum_plugins | Continue when leapp report is missing
+    - name: leapp_missing_yum_plugins | Show remediation command output
       ansible.builtin.debug:
-        msg: "Leapp report missing or did not contain any matches. Skipping this task."
-      when: leapp_report_missing is defined and leapp_report_missing is true
-
+        var: remediation_command_output.stdout_lines
 ...

--- a/roles/remediate/tasks/leapp_move_usr_directory.yml
+++ b/roles/remediate/tasks/leapp_move_usr_directory.yml
@@ -1,76 +1,50 @@
 ---
+- name: leapp_move_usr_directory | Continue when leapp report is missing
+  ansible.builtin.debug:
+    msg: "Leapp report missing. Skipping this task."
+  when: leapp_report_missing_6to7 | default(false)
+
 # This remediation is only necessary when upgrading from RHEL 6 to 7.
 - name: leapp_move_usr_directory | Move /usr to root partition if on another disk or partition.
   vars:
     entry_title: The /usr/ directory is located on a separate partition. The in-place upgrade is not possible.
-    leapp_report_location: /root/preupgrade/result.txt
-  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 6
+    entry_found: "{{ entry_title in (leapp_pre_upgrade_report_6to7.content | b64decode) }}"
+    usr_local_mount_source: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr/local') | map(attribute='device') | d([''], true) | first }}"
+    usr_mount_source: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr') | map(attribute='device') | d([''], true) | first }}"
+    root_mount_source: "{{ ansible_mounts | selectattr('mount', 'eq', '/') | map(attribute='device') | d([''], true) | first }}"
+  when:
+    - not leapp_report_missing_6to7 | default(false)
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version | int == 6
   block:
-    - name: leapp_move_usr_directory | Check that the preupgrade report exists
-      ansible.builtin.stat:
-        path: "{{ leapp_report_location }}"
-      register: leapp_report_stat
+    - name: leapp_move_usr_directory | End execution of playbook if no entry found in leapp report
+      ansible.builtin.debug:
+        msg: "No matching entry found in leapp report. Skipping this task."
+      when: not entry_found | default(false)
 
-    - name: leapp_move_usr_directory | End play if no preupgrade report exists
-      ansible.builtin.fail:
-        msg: "No preupgrade report found. Skipping this task."
-      when: not leapp_report_stat.stat.exists
+    - name: leapp_move_usr_directory | Fail if /usr is not on a separate filesystem
+      ansible.builtin.debug:
+        msg: "This playbook is designed for systems where /usr is mounted on a separate filesystem. /usr is not mounted separately."
+      when:
+        - entry_found
+        - usr_mount_source | length == 0
 
-    - name: leapp_move_usr_directory | Read preupgrade report
-      ansible.builtin.slurp:
-        src: "{{ leapp_report_location }}"
-      register: preupgradereport
+    - name: leapp_move_usr_directory | Skip if /usr is already on root filesystem
+      ansible.builtin.debug:
+        msg: "/usr is already on root filesystem. Skipping this task."
+      when:
+        - entry_found
+        - usr_mount_source | length > 0
+        - usr_mount_source == root_mount_source
 
-    - name: leapp_move_usr_directory | Check if entry exists in preupgrade report
-      ansible.builtin.set_fact:
-        entry_found: "{{ entry_title in (preupgradereport.content | b64decode) }}"
-
-    - name: leapp_move_usr_directory | End execution of playbook if no entry found in preupgrade report
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: not entry_found
-
-    - name: leapp_move_usr_directory | Perform pre-move checks
+    - name: leapp_move_usr_directory | Pre-move checks
+      when:
+        - entry_found
+        - usr_mount_source | length > 0
+        - usr_mount_source != root_mount_source
+      vars:
+        space_needed: "{{ usr_size | int + (usr_local_size | default(0) | int) }}"
       block:
-        - name: leapp_move_usr_directory | Check if /usr is mounted on a separate filesystem
-          ansible.builtin.set_fact:
-            usr_mount_source: "{{ item.device }}"
-          loop: "{{ ansible_mounts }}"
-          when: item.mount == '/usr'
-
-        - name: leapp_move_usr_directory | Check root mount source
-          ansible.builtin.set_fact:
-            root_mount_source: "{{ item.device }}"
-          loop: "{{ ansible_mounts }}"
-          when: item.mount == '/'
-
-        - name: leapp_move_usr_directory | Check if /usr/local is mounted
-          ansible.builtin.set_fact:
-            usr_local_mount_source: "{{ item.device }}"
-          loop: "{{ ansible_mounts }}"
-          when: item.mount == '/usr/local'
-
-        - name: leapp_move_usr_directory | Set mount status facts
-          ansible.builtin.set_fact:
-            usr_is_mounted: "{{ usr_mount_source is defined }}"
-            usr_local_is_mounted: "{{ usr_local_mount_source is defined }}"
-
-        - name: leapp_move_usr_directory | Fail if /usr is not on a separate filesystem
-          ansible.builtin.fail:
-            msg: "This playbook is designed for systems where /usr is mounted on a separate filesystem. /usr is not mounted separately."
-          when: not usr_is_mounted
-
-        - name: leapp_move_usr_directory | Get root mount information
-          ansible.builtin.set_fact:
-            root_mount_source: "{{ item.device }}"
-          loop: "{{ ansible_mounts }}"
-          when: item.mount == '/' and root_mount_source is not defined
-
-        - name: leapp_move_usr_directory | Skip if /usr is already on root filesystem
-          ansible.builtin.fail:
-            msg: "/usr is already on root filesystem. Skipping this task."
-          when: not usr_is_mounted or usr_mount_source == root_mount_source
-
         - name: leapp_move_usr_directory | Check available space on root filesystem
           ansible.builtin.set_fact:
             root_space: "{{ item.block_available * item.block_size }}"
@@ -87,18 +61,19 @@
           ansible.builtin.set_fact:
             usr_local_size: "{{ item.block_available * item.block_size }}"
           loop: "{{ ansible_mounts }}"
-          when: item.mount == '/usr/local' and usr_local_is_mounted
+          when: item.mount == '/usr/local' and usr_local_mount_source | length > 0
 
-        - name: leapp_move_usr_directory | Calculate space needed on root filesystem
+        - name: leapp_move_usr_directory | Check if enough space on root filesystem
           ansible.builtin.set_fact:
-            space_needed: "{{ usr_size | int + (usr_local_size | default(0) | int) }}"
+            enough_space: "{{ space_needed | int <= root_space | int }}"
 
         - name: leapp_move_usr_directory | Fail if not enough space on root filesystem
-          ansible.builtin.fail:
+          ansible.builtin.debug:
             msg: "Not enough space on root filesystem. Need {{ space_needed | int / 1024 }} KB, have {{ root_space | int / 1024 }} KB"
-          when: space_needed | int > root_space | int
+          when: not enough_space | default(false)
 
     - name: leapp_move_usr_directory | Move the /usr directory
+      when: enough_space | default(false)
       block:
         - name: leapp_move_usr_directory | Ensure temporary mount directories exist
           ansible.builtin.file:
@@ -118,7 +93,7 @@
             mode: "0755"
             owner: root
             group: root
-          when: usr_local_is_mounted
+          when: usr_local_mount_source | length > 0
 
         - name: leapp_move_usr_directory | Ensure /root partition is mounted to /mnt/root
           ansible.posix.mount:
@@ -149,13 +124,13 @@
             fstype: ext4
             opts: bind
             state: mounted
-          when: usr_local_is_mounted
+          when: usr_local_mount_source | length > 0
 
         - name: leapp_move_usr_directory | Copy /usr/local to /mnt/root/usr/local
           ansible.builtin.shell: |
             set -o pipefail
             rsync -aHAXv /mnt/usr_local/* /mnt/root/usr/local/
-          when: usr_local_is_mounted
+          when: usr_local_mount_source | length > 0
           changed_when: true
 
         - name: leapp_move_usr_directory | Ensure /usr line is removed from /etc/fstab
@@ -169,8 +144,12 @@
             path: /etc/fstab
             regexp: "/usr/local "
             state: absent
-          when: usr_local_is_mounted
+          when: usr_local_mount_source | length > 0
 
+        # TODO: Do we need to reboot the system here?  Or can we move this
+        # to a handler?  Do any subsequent tasks require access to /usr/local?
+        # If we do need to reboot here, we should 1) add a conditional so that we
+        # only reboot if necessary, and 2) check if the filesystems are mounted
         - name: leapp_move_usr_directory | Reboot the system
           ansible.builtin.reboot:
             msg: "Rebooting the system to complete the move of /usr"
@@ -178,9 +157,4 @@
             pre_reboot_delay: "{{ pre_reboot_delay }}"
             post_reboot_delay: "{{ post_reboot_delay }}"
 
-  rescue:
-    - name: leapp_move_usr_directory | Continue when /usr is not on a separate filesystem
-      ansible.builtin.debug:
-        msg: "Problems found during execution; skipping this task."
-      when: not usr_is_mounted
 ...

--- a/roles/remediate/tasks/leapp_multiple_kernels.yml
+++ b/roles/remediate/tasks/leapp_multiple_kernels.yml
@@ -17,7 +17,7 @@
       ansible.builtin.command: grubby --set-default /boot/vmlinuz-{{ installed_kernels.stdout_lines[0] }}
       when: installed_kernels.stdout_lines[0] != current_kernel.stdout
       register: set_default_kernel
-      changed_when: set_default_kernel.rc == 0
+      changed_when: set_default_kernel is success
 
     - name: leapp_multiple_kernels | Update-and-reboot | Reboot when updates applied
       ansible.builtin.reboot:
@@ -26,6 +26,8 @@
       timeout: "{{ reboot_timeout }}"
       when: installed_kernels.stdout_lines[0] != current_kernel.stdout
 
+    # TODO: This is slow.  Instead, use filters/map to construct the list
+    # of package names to remove and pass the list as name:
     - name: leapp_multiple_kernels | Remove old kernels
       ansible.builtin.package:
         name: kernel-core-{{ item }}

--- a/roles/remediate/tasks/leapp_newest_kernel_not_in_use.yml
+++ b/roles/remediate/tasks/leapp_newest_kernel_not_in_use.yml
@@ -15,28 +15,23 @@
       register: default_kernel_version
       changed_when: false
 
-    # If the two strings are the same, fail out to the rescue block
     - name: leapp_newest_kernel_not_in_use | Check the kernel versions
-      ansible.builtin.set_fact:
-        leapp_newest_kernel_in_use: true
-      when: installed_kernels.stdout_lines[0] == default_kernel_version.stdout
-      failed_when: installed_kernels.stdout_lines[0] == default_kernel_version.stdout
-
-    - name: leapp_newest_kernel_not_in_use | Set default kernel to latest
-      ansible.builtin.command: grubby --set-default /boot/vmlinuz-{{ installed_kernels.stdout_lines[0] }}
-      register: set_default_kernel
-      changed_when: set_default_kernel.rc == 0
-
-    - name: leapp_newest_kernel_not_in_use | Update-and-reboot | Reboot when updates applied
-      ansible.builtin.reboot:
-        reboot_timeout: "{{ reboot_timeout }}"
-        post_reboot_delay: "{{ post_reboot_delay }}"
-      timeout: "{{ reboot_timeout }}"
-
-  rescue:
-    - name: leapp_newest_kernel_not_in_use | Continue when the latest version is the default
       ansible.builtin.debug:
-        msg: "The newest kernel is already in use. Skipping this task."
-      when: leapp_newest_kernel_in_use is defined and leapp_newest_kernel_in_use is true
+        msg: "The newest kernel {{ installed_kernels.stdout_lines[0] }} is already in use. Skipping this task."
+      when: installed_kernels.stdout_lines[0] == default_kernel_version.stdout
+
+    - name: leapp_newest_kernel_not_in_use | Process remediation
+      when: installed_kernels.stdout_lines[0] != default_kernel_version.stdout
+      block:
+        - name: leapp_newest_kernel_not_in_use | Set default kernel to latest
+          ansible.builtin.command: grubby --set-default /boot/vmlinuz-{{ installed_kernels.stdout_lines[0] }}
+          register: set_default_kernel
+          changed_when: set_default_kernel is success
+
+        - name: leapp_newest_kernel_not_in_use | Update-and-reboot | Reboot when updates applied
+          ansible.builtin.reboot:
+            reboot_timeout: "{{ reboot_timeout }}"
+            post_reboot_delay: "{{ post_reboot_delay }}"
+          timeout: "{{ reboot_timeout }}"
 
 ...

--- a/roles/remediate/tasks/leapp_nfs_detected.yml
+++ b/roles/remediate/tasks/leapp_nfs_detected.yml
@@ -1,78 +1,52 @@
 ---
+- name: leapp_nfs_detected | Continue when leapp report is missing
+  ansible.builtin.debug:
+    msg: "Leapp report missing. Skipping this task."
+  when: leapp_report_missing | default(false)
+
 - name: leapp_nfs_detected | Disable NFS temporarily for the upgrade
   vars:
     entry_title: Use of NFS detected. Upgrade can't proceed
-    leapp_report_location: /var/log/leapp/leapp-report.json
+    summaries: "{{ leapp_report_data.entries | selectattr('title', 'match', entry_title) | map(attribute='summary') | list }}"
+    summary: "{{ summaries | first if summaries | length > 0 else '' }}"
+    split_summary: "{{ summary.split('- NFS')[1:] | map('regex_replace', '^[\\s\\n]+', '- NFS ') | list }}"
+  when: not leapp_report_missing | default(false)
   block:
-    - name: leapp_nfs_detected | Check that the leapp-report.json exists
-      ansible.builtin.stat:
-        path: "{{ leapp_report_location }}"
-      register: leapp_report_stat
-
-    - name: leapp_nfs_detected | End play if no leapp report exists
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      when: leapp_report_stat.stat.exists is false
-      failed_when: leapp_report_stat.stat.exists is false
-
-    - name: leapp_nfs_detected | Read leapp report
-      ansible.builtin.slurp:
-        src: "{{ leapp_report_location }}"
-      register: leappreport
-
-    - name: leapp_nfs_detected | Parse leapp report to json
-      ansible.builtin.set_fact:
-        leappreportdata: "{{ leappreport.content | b64decode | from_json }}"
-
-    - name: leapp_nfs_detected | Find matching entries
-      ansible.builtin.set_fact:
-        summary: "{{ item.summary }}"
-      loop: "{{ leappreportdata.entries }}"
-      when: item.title is match(entry_title) and (item.summary | length > 0)
-
     - name: leapp_nfs_detected | End execution of playbook if no entry found in leapp report
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: summary is not defined
-
-    - name: leapp_nfs_detected | Split summary
-      ansible.builtin.set_fact:
-        split_summary: "{{ summary.split('- NFS')[1:] | map('regex_replace', '^[\\s\\n]+', '- NFS ') | list }}"
-    - name: leapp_nfs_detected | Get fstab_entries
-      ansible.builtin.set_fact:
-        fstab_entries: "{{ item | split('- NFS shares found in /etc/fstab:') | last | trim | regex_findall('- ([^ ]+)', '\\1') }}"
-      loop: "{{ split_summary }}"
-      when: "'- NFS shares found in /etc/fstab:' in item"
-    - name: leapp_nfs_detected | Get nfs_mounts
-      ansible.builtin.set_fact:
-        nfs_mounts: "{{ item | split('- NFS shares currently mounted:') | last | trim | regex_findall('- ([^ ]+)', '\\1') }}"
-      loop: "{{ split_summary }}"
-      when: "'- NFS shares currently mounted:' in item"
-    - name: leapp_nfs_detected | Get systemd_mounts
-      ansible.builtin.set_fact:
-        systemd_mounts: "{{ item | split('- NFS mounts configured with systemd-mount:') | last | trim | regex_findall('- ([^ ]+)', '\\1') }}"
-      loop: "{{ split_summary }}"
-      when: "'- NFS mounts configured with systemd-mount:' in item"
-
-    - name: leapp_nfs_detected | Comment NFS shares in /etc/fstab
-      loop: "{{ fstab_entries }}"
-      ansible.builtin.shell: |
-        set -o pipefail
-        entry="{{ item }}"
-        grep -qF "$entry" /etc/fstab && sed -i "s|^$entry|# $entry|" /etc/fstab
-      when: fstab_entries is defined
-      changed_when: fstab_entries is defined
-
-    - name: leapp_nfs_detected | Unmount NFS Mounts
-      ansible.builtin.command: umount -l {{ item }}
-      loop: "{{ nfs_mounts }}"
-      when: nfs_mounts is defined
-      changed_when: nfs_mounts is defined
-
-  rescue:
-    - name: leapp_nfs_detected | Continue when leapp report is missing
       ansible.builtin.debug:
-        msg: "Leapp report missing or did not contain any matches. Skipping this task."
-      when: leapp_report_missing is defined and leapp_report_missing is true
+        msg: "No matching entry found in leapp report. Skipping this task."
+      when: summary | length == 0 or split_summary | length == 0
+
+    - name: leapp_nfs_detected | Process remediation
+      when:
+        - summary | length > 0
+        - split_summary | length > 0
+      block:
+        - name: leapp_nfs_detected | Get fstab_entries
+          ansible.builtin.set_fact:
+            fstab_entries: "{{ item | split('- NFS shares found in /etc/fstab:') | last | trim | regex_findall('- ([^ ]+)', '\\1') }}"
+          loop: "{{ split_summary }}"
+          when: "'- NFS shares found in /etc/fstab:' in item"
+
+        - name: leapp_nfs_detected | Get nfs_mounts
+          ansible.builtin.set_fact:
+            nfs_mounts: "{{ item | split('- NFS shares currently mounted:') | last | trim | regex_findall('- ([^ ]+)', '\\1') }}"
+          loop: "{{ split_summary }}"
+          when: "'- NFS shares currently mounted:' in item"
+
+        - name: leapp_nfs_detected | Comment NFS shares in /etc/fstab
+          loop: "{{ fstab_entries }}"
+          ansible.builtin.shell: |
+            set -o pipefail
+            entry="{{ item }}"
+            grep -qF "$entry" /etc/fstab && sed -i "s|^$entry|# $entry|" /etc/fstab
+          when: fstab_entries is defined
+          changed_when: fstab_entries is defined
+
+        - name: leapp_nfs_detected | Unmount NFS Mounts
+          ansible.builtin.command: umount -l {{ item | quote }}
+          loop: "{{ nfs_mounts }}"
+          when: nfs_mounts is defined
+          changed_when: nfs_mounts is defined
 
 ...

--- a/roles/remediate/tasks/leapp_non_persistent_partitions.yml
+++ b/roles/remediate/tasks/leapp_non_persistent_partitions.yml
@@ -2,51 +2,47 @@
 - name: leapp_non_persistent_partitions | Add mount entry to /etc/fstab for non persistent /var/lib/leapp mount
   block:
     - name: leapp_non_persistent_partitions | Check if /var/lib/leapp exists in /etc/fstab
-      ansible.builtin.command: grep '/var/lib/leapp' /etc/fstab
+      ansible.builtin.command: grep /var/lib/leapp /etc/fstab
       register: fstab_output
-      changed_when: fstab_output.stdout is defined
-
-    - name: leapp_non_persistent_partitions | End play if no leapp report exists
-      ansible.builtin.set_fact:
-        leapp_mount_missing: true
-      when: fstab_output.stdout is undefined
-      failed_when: fstab_output.stdout is undefined
-
-    - name: leapp_non_persistent_partitions | Get /var/lib/leapp mount device
-      ansible.builtin.command: findmnt -nr -o SOURCE /var/lib/leapp
-      register: mount_device_output
       changed_when: false
+      failed_when: fstab_output.rc not in [0, 1]
 
-    - name: leapp_non_persistent_partitions | Get /var/lib/leapp mount filesystem type
-      ansible.builtin.command: findmnt -nr -o FSTYPE /var/lib/leapp
-      register: mount_filesystem_output
-      changed_when: false
-
-    - name: leapp_non_persistent_partitions | Get /var/lib/leapp mount options
-      ansible.builtin.command: findmnt -nr -o OPTIONS /var/lib/leapp
-      register: mount_options_output
-      changed_when: false
-
-    - name: leapp_non_persistent_partitions | Get UUID for the device
-      ansible.builtin.command: blkid -s UUID -o value {{ mount_device_output.stdout }}
-      register: uuid_output
-      failed_when: true
-      changed_when: false
-
-    - name: leapp_non_persistent_partitions | Add /var/lib/leapp to /etc/fstab
-      ansible.builtin.lineinfile:
-        path: /etc/fstab
-        line: UUID={{ uuid_output.stdout }} /var/lib/leapp {{ mount_filesystem_output.stdout }} {{ mount_options_output.stdout }} 0 0
-      when:
-        - "'/var/lib/leapp' not in fstab_output.stdout"
-        - uuid_output.stdout is defined
-        - mount_filesystem_output.stdout is defined
-        - mount_options_output.stdout is defined
-
-  rescue:
     - name: leapp_non_persistent_partitions | Continue when /var/lib/leapp is missing
       ansible.builtin.debug:
         msg: "/var/lib/leapp mount point not found. Skipping this task."
-      when: leapp_mount_missing is defined and leapp_mount_missing is true
+      when: fstab_output.rc == 1
+
+    - name: leapp_non_persistent_partitions | Process remediation
+      when: fstab_output.rc == 0
+      block:
+        - name: leapp_non_persistent_partitions | Get /var/lib/leapp mount device
+          ansible.builtin.command: findmnt -nr -o SOURCE /var/lib/leapp
+          register: mount_device_output
+          changed_when: false
+
+        - name: leapp_non_persistent_partitions | Get /var/lib/leapp mount filesystem type
+          ansible.builtin.command: findmnt -nr -o FSTYPE /var/lib/leapp
+          register: mount_filesystem_output
+          changed_when: false
+
+        - name: leapp_non_persistent_partitions | Get /var/lib/leapp mount options
+          ansible.builtin.command: findmnt -nr -o OPTIONS /var/lib/leapp
+          register: mount_options_output
+          changed_when: false
+
+        - name: leapp_non_persistent_partitions | Get UUID for the device
+          ansible.builtin.command: blkid -s UUID -o value {{ mount_device_output.stdout }}
+          register: uuid_output
+          changed_when: false
+
+        - name: leapp_non_persistent_partitions | Add /var/lib/leapp to /etc/fstab
+          ansible.builtin.lineinfile:
+            path: /etc/fstab
+            line: UUID={{ uuid_output.stdout }} /var/lib/leapp {{ mount_filesystem_output.stdout }} {{ mount_options_output.stdout }} 0 0
+          when:
+            - "'/var/lib/leapp' not in fstab_output.stdout"
+            - uuid_output.stdout is defined
+            - mount_filesystem_output.stdout is defined
+            - mount_options_output.stdout is defined
 
 ...

--- a/roles/remediate/tasks/leapp_non_standard_openssl_config.yml
+++ b/roles/remediate/tasks/leapp_non_standard_openssl_config.yml
@@ -1,34 +1,34 @@
 ---
 - name: leapp_non_standard_openssl_config | Adjust openssl.cnf configuration for default_modules
-  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 8
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version | int == 8
+  vars:
+    openssl_cnf_path: /etc/pki/tls/openssl.cnf
   block:
     - name: leapp_non_standard_openssl_config | Check if openssl.cnf exists
       ansible.builtin.stat:
-        path: /etc/pki/tls/openssl.cnf
+        path: "{{ openssl_cnf_path }}"
       register: openssl_cnf_stat
 
     - name: leapp_non_standard_openssl_config | End execution of playbook if openssl.cnf does not exist
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      when: openssl_cnf_stat.stat.exists is false
-      failed_when: openssl_cnf_stat.stat.exists is false
-
-    - name: leapp_non_standard_openssl_config | Back up openssl.cnf
-      ansible.builtin.copy:
-        src: /etc/pki/tls/openssl.cnf
-        dest: /etc/pki/tls/openssl.cnf.rhel8-bkup
-        remote_src: true
-        mode: "0644"
-
-    - name: leapp_non_standard_openssl_config | Remove openssl.cnf
-      ansible.builtin.file:
-        path: /etc/pki/tls/openssl.cnf
-        state: absent
-
-  rescue:
-    - name: leapp_non_standard_openssl_config | Continue when leapp report is missing
       ansible.builtin.debug:
-        msg: "Leapp report missing or did not contain any matches. Skipping this task."
-      when: leapp_report_missing is defined and leapp_report_missing is true
+        msg: "{{ openssl_cnf_path }} does not exist. Skipping this task."
+      when: not openssl_cnf_stat.stat.exists
+
+    - name: leapp_non_standard_openssl_config | Process remediation
+      when: openssl_cnf_stat.stat.exists
+      block:
+        - name: leapp_non_standard_openssl_config | Back up openssl.cnf
+          ansible.builtin.copy:
+            src: "{{ openssl_cnf_path }}"
+            dest: "{{ openssl_cnf_path }}.rhel8-bkup"
+            remote_src: true
+            mode: "0644"
+
+        - name: leapp_non_standard_openssl_config | Remove openssl.cnf
+          ansible.builtin.file:
+            path: "{{ openssl_cnf_path }}"
+            state: absent
 
 ...

--- a/roles/remediate/tasks/leapp_old_postgresql_data.yml
+++ b/roles/remediate/tasks/leapp_old_postgresql_data.yml
@@ -1,40 +1,36 @@
 ---
 - name: leapp_old_postgresql_data | Backup and then remove /var/lib/pgsql/data for remediation
+  vars:
+    postgresql_data_path: /var/lib/pgsql/data
   block:
     - name: leapp_old_postgresql_data | Check if /var/lib/pgsql/data exists
       ansible.builtin.stat:
-        path: /var/lib/pgsql/data
+        path: "{{ postgresql_data_path }}"
       register: pgsql_data_stat
 
     - name: leapp_old_postgresql_data | End play if /var/lib/psql/data does not exist
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      when: pgsql_data_stat.stat.exists is false
-      failed_when: pgsql_data_stat.stat.exists is false
-
-    - name: leapp_old_postgresql_data | Set backup filename with timestamp
-      ansible.builtin.set_fact:
-        backup_filename: pgsql_data_backup_{{ ansible_date_time.iso8601_basic_short }}.tar.gz
-
-    - name: leapp_old_postgresql_data | Ensure /var/backups exists
-      ansible.builtin.file:
-        path: /var/backups
-        state: directory
-        mode: "0755"
-
-    - name: leapp_old_postgresql_data | Backup /var/lib/pgsql/data
-      community.general.archive:
-        dest: /var/backups/{{ backup_filename }}
-        path: /var/lib/pgsql/data
-        format: gz
-        force_archive: true
-        remove: true
-        mode: "0755"
-
-  rescue:
-    - name: leapp_old_postgresql_data | Continue when leapp report is missing
       ansible.builtin.debug:
-        msg: "Leapp report missing or did not contain any matches. Skipping this task."
-      when: leapp_report_missing is defined and leapp_report_missing is true
+        msg: "{{ postgresql_data_path }} does not exist. Skipping this task."
+      when: not pgsql_data_stat.stat.exists
+
+    - name: leapp_old_postgresql_data | Process remediation
+      when: pgsql_data_stat.stat.exists
+      block:
+        - name: leapp_old_postgresql_data | Ensure /var/backups exists
+          ansible.builtin.file:
+            path: /var/backups
+            state: directory
+            mode: "0755"
+
+        - name: leapp_old_postgresql_data | Backup /var/lib/pgsql/data
+          community.general.archive:
+            dest: /var/backups/{{ backup_filename }}
+            path: "{{ postgresql_data_path }}"
+            format: gz
+            force_archive: true
+            remove: true
+            mode: "0755"
+          vars:
+            backup_filename: pgsql_data_backup_{{ ansible_date_time.iso8601_basic_short }}.tar.gz
 
 ...

--- a/roles/remediate/tasks/leapp_pam_tally2.yml
+++ b/roles/remediate/tasks/leapp_pam_tally2.yml
@@ -1,7 +1,9 @@
 ---
 - name: leapp_pam_tally2 | Remove pam_tally2 modules
   # pam_tally2 only existed in RHEL 5-7, skip if this is not a RHEL 7 upgrade
-  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 7
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version | int == 7
   block:
     - name: leapp_pam_tally2 | Find all instances of pam_tally2 in /etc/pam.d/
       ansible.builtin.find:

--- a/roles/remediate/tasks/leapp_partitions_with_noexec.yml
+++ b/roles/remediate/tasks/leapp_partitions_with_noexec.yml
@@ -6,7 +6,7 @@
         set -o pipefail
         mount | grep -E '(/var|/var/lib|/var/lib/leapp).*noexec'
       register: mountpoints
-      changed_when: mountpoints.rc == 0
+      changed_when: mountpoints is success
       failed_when: false
 
     - name: leapp_partitions_with_noexec | Go through the the mountpoints and remount
@@ -24,7 +24,7 @@
         set -o pipefail
         sed -i '/\/var\/lib\/leapp\|\/var\/lib\|\/var/s/noexec/exec/' /etc/fstab
       register: sed_result
-      changed_when: sed_result.rc == 0
+      changed_when: sed_result is success
       when: mountpoints.stdout_lines | length > 0
 
 ...

--- a/roles/remediate/tasks/leapp_relative_symlinks.yml
+++ b/roles/remediate/tasks/leapp_relative_symlinks.yml
@@ -1,54 +1,38 @@
 ---
+- name: leapp_relative_symlinks | Continue when leapp report is missing
+  ansible.builtin.debug:
+    msg: "Leapp report missing. Skipping this task."
+  when: leapp_report_missing | default(false)
+
 - name: leapp_relative_symlinks | Change symbolic links in root directory to be relative
+  when: not leapp_report_missing | default(false)
   vars:
-    leapp_report_location: /var/log/leapp/leapp-report.json
     entry_title: Upgrade requires links in root directory to be relative
+    remediation_matches: "{{ leapp_report_data.entries | selectattr('title', 'match', entry_title) |
+      map(attribute='detail.remediations') | flatten | list }}"
+    remediation: "{{ remediation_matches | selectattr('type', 'eq', 'command') | first
+      if remediation_matches | length > 0 else {} }}"
   block:
-    - name: leapp_relative_symlinks | Check that the leapp-report.json with remediation command exists
-      ansible.builtin.stat:
-        path: "{{ leapp_report_location }}"
-      register: leapp_report_stat
-
-    - name: leapp_relative_symlinks | End execution of playbook if leapp report does not exist (not possible to remediate)
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      when: leapp_report_stat.stat.exists is false
-      failed_when: leapp_report_stat.stat.exists is false
-
-    - name: leapp_relative_symlinks | Read leapp report
-      ansible.builtin.slurp:
-        src: "{{ leapp_report_location }}"
-      register: leappreport
-
-    - name: leapp_relative_symlinks | Parse leapp report to json
-      ansible.builtin.set_fact:
-        leappreportdata: "{{ leappreport.content | b64decode | from_json }}"
-
-    - name: leapp_relative_symlinks | Find matching entries
-      ansible.builtin.set_fact:
-        remediation: "{{ item.detail.remediations | selectattr('type', 'eq', 'command') | first }}"
-      loop: "{{ leappreportdata.entries }}"
-      when: item.title == entry_title and (item.detail.remediations | selectattr('type', 'eq', 'command') | list | length > 0)
-
     - name: leapp_relative_symlinks | End execution of playbook if no entry found in leapp report
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: remediation is not defined
-
-    - name: leapp_relative_symlinks | Output command to be executed
       ansible.builtin.debug:
-        msg: "{{ remediation.context | last }}"
+        msg: "No matching entry found in leapp report. Skipping this task."
+      when: remediation | length == 0
 
-    - name: leapp_relative_symlinks | Set links in root directory to be relative
-      ansible.builtin.command: "{{ remediation.context | last }}"
-      when: remediation is defined
-      register: leapp_relative_symlinks
-      changed_when: leapp_relative_symlinks.rc == 0
+    - name: leapp_relative_symlinks | Process remediation
+      when: remediation | length > 0
+      block:
+        - name: leapp_relative_symlinks | Output command to be executed
+          ansible.builtin.debug:
+            msg: "{{ remediation.context }}"
 
-  rescue:
-    - name: leapp_relative_symlinks | Continue when leapp report is missing
-      ansible.builtin.debug:
-        msg: "Leapp report missing or did not contain any matches. Skipping this task."
-      when: leapp_report_missing is defined and leapp_report_missing is true
+        # The old version passed the list directly to the command.  I didn't think
+        # this was possible.  Guard against something weird here.  Assume non-string
+        # is a list.
+        - name: leapp_relative_symlinks | Set links in root directory to be relative
+          ansible.builtin.command:
+            argv: "{{ remediation.context if not remediation.context is string else omit }}"
+            cmd: "{{ remediation.context if remediation.context is string else omit }}"
+          register: leapp_relative_symlinks
+          changed_when: leapp_relative_symlinks is success
 
 ...

--- a/roles/remediate/tasks/leapp_rpms_with_rsa_sha1_detected.yml
+++ b/roles/remediate/tasks/leapp_rpms_with_rsa_sha1_detected.yml
@@ -1,55 +1,38 @@
 ---
+- name: leapp_rpms_with_rsa_sha1_detected | Continue when leapp report is missing
+  ansible.builtin.debug:
+    msg: "Leapp report missing. Skipping this task."
+  when: leapp_report_missing | default(false)
+
 - name: leapp_rpms_with_rsa_sha1_detected | Remove RPMs with RSA/SHA1 signature
   vars:
-    leapp_report_location: /var/log/leapp/leapp-report.json
     entry_title: Detected RPMs with RSA/SHA1 signature
-  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 8
+    summaries: "{{ leapp_report_data.entries | selectattr('title', 'match', entry_title) |
+      map(attribute='summary') | list }}"
+    summary: "{{ summaries | first if summaries | length > 0 else '' }}"
+  when:
+    - not leapp_report_missing | default(false)
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version | int == 8
   block:
-    - name: leapp_rpms_with_rsa_sha1_detected | Check that the leapp-report.json exists
-      ansible.builtin.stat:
-        path: "{{ leapp_report_location }}"
-      register: leapp_report_stat
-
-    - name: leapp_rpms_with_rsa_sha1_detected | End play if no leapp report exists
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      when: leapp_report_stat.stat.exists is false
-      failed_when: leapp_report_stat.stat.exists is false
-
-    - name: leapp_rpms_with_rsa_sha1_detected | Read leapp report
-      ansible.builtin.slurp:
-        src: "{{ leapp_report_location }}"
-      register: leappreport
-
-    - name: leapp_rpms_with_rsa_sha1_detected | Parse leapp report to json
-      ansible.builtin.set_fact:
-        leappreportdata: "{{ leappreport.content | b64decode | from_json }}"
-
-    - name: leapp_rpms_with_rsa_sha1_detected | Find matching entries
-      ansible.builtin.set_fact:
-        summary: "{{ item.summary }}"
-      loop: "{{ leappreportdata.entries }}"
-      when: item.title is match(entry_title) and (item.summary | length > 0)
-
     - name: leapp_rpms_with_rsa_sha1_detected | End execution of playbook if no entry found in leapp report
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: summary is not defined
-
-    - name: leapp_rpms_with_rsa_sha1_detected | Parse bad_pkgs
-      ansible.builtin.set_fact:
-        bad_pkgs: "{{ summary | split('The list of problematic packages:') | last | trim | regex_findall('- ([^ ]+)', '\\1') }}"
-
-    - name: leapp_rpms_with_rsa_sha1_detected | Remove bad packages
-      ansible.builtin.dnf:
-        name: "{{ item }}"
-        state: absent
-      loop: "{{ bad_pkgs }}"
-
-  rescue:
-    - name: leapp_rpms_with_rsa_sha1_detected | Continue when leapp report is missing
       ansible.builtin.debug:
-        msg: "Leapp report missing or did not contain any matches. Skipping this task."
-      when: leapp_report_missing is defined and leapp_report_missing is true
+        msg: "No matching entry found in leapp report. Skipping this task."
+      when: summary | length == 0
+
+    - name: leapp_rpms_with_rsa_sha1_detected | Process remediation
+      when: summary | length > 0
+      block:
+        - name: leapp_rpms_with_rsa_sha1_detected | Parse bad_pkgs
+          ansible.builtin.set_fact:
+            bad_pkgs: "{{ summary | split('The list of problematic packages:') | last | trim | regex_findall('- ([^ ]+)', '\\1') }}"
+
+        # TODO: Pass the bad_pkgs list directly to the dnf command?  Is there some reason
+        # this has to be done one at a time?  It is much slower this way.
+        - name: leapp_rpms_with_rsa_sha1_detected | Remove bad packages
+          ansible.builtin.dnf:
+            name: "{{ item }}"
+            state: absent
+          loop: "{{ bad_pkgs }}"
 
 ...

--- a/roles/remediate/tasks/leapp_unavailable_kde.yml
+++ b/roles/remediate/tasks/leapp_unavailable_kde.yml
@@ -2,7 +2,9 @@
 # kde is not available in RHEL 8
 # We will only install the gnome desktop environment if KDE is installed
 - name: leapp_unavailable_kde | Install the GNOME desktop environment to be able to upgrade
-  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 7
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version | int == 7
   block:
     - name: leapp_unavailable_kde | Check if the KDE desktop environment is installed
       ansible.builtin.command: # noqa: command-instead-of-module

--- a/roles/remediate/tasks/leapp_vdo_check_needed.yml
+++ b/roles/remediate/tasks/leapp_vdo_check_needed.yml
@@ -1,6 +1,8 @@
 ---
 - name: leapp_vdo_check_needed | Install vdo package - required for performing the VDO check of block devices
-  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 8
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version | int == 8
   block:
     - name: leapp_vdo_check_needed | Install vdo package
       ansible.builtin.dnf:

--- a/roles/remediate/tasks/main.yml
+++ b/roles/remediate/tasks/main.yml
@@ -1,11 +1,49 @@
 ---
 # tasks file for remediations
+- name: Run remediations
+  vars:
+    leapp_report_location_6to7: /root/preupgrade/result.txt
+  block:
+    - name: Check that the leapp-report.json exists
+      ansible.builtin.stat:
+        path: "{{ leapp_report_location }}"
+      register: leapp_report_stat
 
-- name: Remediate the system
-  ansible.builtin.include_tasks: "{{ remediation_item }}.yml"
-  loop: "{{ remediation_playbooks }}"
-  loop_control:
-    loop_var: remediation_item
-  when: remediation_item in remediation_todo
+    - name: Set leapp_report_missing to true if the leapp-report.json does not exist
+      ansible.builtin.set_fact:
+        leapp_report_missing: true
+      when: not leapp_report_stat.stat.exists
 
+    - name: Read leapp report
+      ansible.builtin.slurp:
+        src: "{{ leapp_report_location }}"
+      when: leapp_report_stat.stat.exists
+      register: leapp_report_content
+
+    - name: Parse leapp report
+      ansible.builtin.set_fact:
+        leapp_report_data: "{{ leapp_report_content.content | b64decode | from_json }}"
+      when: leapp_report_content.content | length > 0
+
+    - name: Check that the 6to7 preupgrade report exists
+      ansible.builtin.stat:
+        path: "{{ leapp_report_location_6to7 }}"
+      register: leapp_report_stat_6to7
+
+    - name: Set leapp_report_missing_6to7 to true if the 6to7 preupgrade report does not exist
+      ansible.builtin.set_fact:
+        leapp_report_missing_6to7: true
+      when: not leapp_report_stat_6to7.stat.exists
+
+    - name: Read 6to7 preupgrade report
+      ansible.builtin.slurp:
+        src: "{{ leapp_report_location_6to7 }}"
+      register: leapp_pre_upgrade_report_6to7
+      when: leapp_report_stat_6to7.stat.exists
+
+    - name: Remediate the system
+      ansible.builtin.include_tasks: "{{ remediation_item }}.yml"
+      loop: "{{ remediation_playbooks | intersect(remediation_todo) }}"
+      loop_control:
+        loop_var: remediation_item
 ...

--- a/tests/tasks/common_upgrade_tasks.yml
+++ b/tests/tasks/common_upgrade_tasks.yml
@@ -28,7 +28,14 @@
     loop_var: inhibitor_title
   vars:
     map_key: "{{ title_map.keys() | select('in', inhibitor_title) | first | default('') }}"
-  when: map_key != ''
+  when:
+    - not leapp_test_all_remediations | d(false)
+    - map_key != ''
+
+- name: common_upgrade_tasks | Enable all remediations
+  ansible.builtin.set_fact:
+    remediation_todo: "{{ common_title_map.values() | list }}"
+  when: leapp_test_all_remediations | d(false)
 
 - name: common_upgrade_tasks | Debug remediation_todo
   ansible.builtin.debug:


### PR DESCRIPTION
There was a lot of code duplication in the remedation task files.  This has been extracted
into the remediation role main task file.

The remediation tasks were using fail/rescue for flow control, which makes looking at the
logs very confusing, as you really have to know which tasks to exclude when looking for errors.
Instead, use plain old conditionals with blocks for tasks to run conditionally.  NOTE: The
old way of using `rescue` would essentially catch and ignore all errors - this seems
wrong to me, but perhaps there is a reason.  This means that now, remediation may raise
errors where before it would not.

Use ansible good practices:

* Use `vars` instead of `set_fact` and keep the variables set at the lowest necessary scope
* Use filters instead of loops
* Use conditional evaluation instead of comparing a value `== true`
* Use tests such as `is success` rather than looking at the register rc value directly

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
