### PR TITLE
Add ability to run test plan on local and 1minutetip images provided in an environment-file, fix setting file when configuring yum repos

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -1,6 +1,9 @@
 ---
 name: Run integration tests in Testing Farm
 on:
+  # Tests that run on issue_comment are run from the main branch.
+  # Changes to this workflow and to tmt plans and tests need to be merged to
+  # main first appear in CI runs.
   issue_comment:
     types:
       - created

--- a/changelogs/fragments/custom_local_repos_fix_file.yml
+++ b/changelogs/fragments/custom_local_repos_fix_file.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix configuring local_repos_leapp yum repositories file. Previously, it was hardcoded to __leapp_repo_file regardless of whether file key was provided with one of local_repos_leapp
+...

--- a/plans/test_playbooks.fmf
+++ b/plans/test_playbooks.fmf
@@ -1,30 +1,69 @@
 summary: Test Ansible playbooks from control node against managed nodes
 tag: test_playbook
 adjust:
-  - when: initiator is not defined
+  # Running locally on local VMs
+  # URLs for images are provided by an environment-file below. Example run:
+  # tmt -c COMPOSE_MANAGED_NODE=rhel8 try -p /plans/test_playbooks
+  - when: >-
+      initiator is not defined
+      and 1minutetip is not defined
+    provision+:
+      - name: control-node01
+        role: control_node
+        how: virtual
+        connection: system
+        image: ${RHEL_9_8_image}
+  - when: >-
+      initiator is not defined
+      and 1minutetip is not defined
+      and COMPOSE_MANAGED_NODE == rhel7
+    provision+:
+      - name: managed-node01
+        role: managed_node
+        how: virtual
+        connection: system
+        image: ${RHEL_7_9_image}
+  - when: >-
+      initiator is not defined
+      and 1minutetip is not defined
+      and COMPOSE_MANAGED_NODE=rhel8
+    provision+:
+      - name: managed-node01
+        role: managed_node
+        how: virtual
+        connection: system
+        image: ${RHEL_8_10_image}
+  - when: >-
+      initiator is not defined
+      and 1minutetip is not defined
+      and COMPOSE_MANAGED_NODE=rhel9
+    provision+:
+      - name: managed-node01
+        role: managed_node
+        how: virtual
+        connection: system
+        image: ${RHEL_9_6_image}
+
+  # Running locally by provisioning 1minutetip VMs. Example run:
+  # tmt -c 1minutetip=true -c COMPOSE_MANAGED_NODE=rhel8 try -p /plans/test_playbooks
+  - when: >-
+      initiator is not defined
+      and 1minutetip == true
     provision+:
       - name: control-node01
         role: control_node
         how: minute
         image: rhel9
-  - when: initiator is not defined and COMPOSE_MANAGED_NODE=rhel7
+  - when: >-
+      initiator is not defined
+      and 1minutetip == true
     provision+:
       - name: managed-node01
         role: managed_node
         how: minute
-        image: rhel7
-  - when: initiator is not defined and COMPOSE_MANAGED_NODE=rhel8
-    provision+:
-      - name: managed-node01
-        role: managed_node
-        how: minute
-        image: rhel8
-  - when: initiator is not defined and COMPOSE_MANAGED_NODE=rhel9
-    provision+:
-      - name: managed-node01
-        role: managed_node
-        how: minute
-        image: rhel-9.6
+        image: $@COMPOSE_MANAGED_NODE
+
+  # Running from CI in testing-farm
   - when: initiator == testing-farm
     provision+:
       - name: control-node01
@@ -49,11 +88,17 @@ adjust:
         how: artemis
         image: ${COMPOSE_MANAGED_NODE}
         arch: x86_64
+# URL or path to environment file that provides vars for images and repositories
+# environment-file:
+#   - https... or leapp_coll_env_file
+environment-file:
+  - https://gitlab.cee.redhat.com/oamg/tests-ansible-collection-leapp/-/raw/main/leapp_coll_env_file?ref_type=heads
 environment:
     SR_ANSIBLE_VER: 2.17
     SR_REPO_NAME: ""
     SR_PYTHON_VERSION: 3.12
-    SR_ONLY_TESTS: ""
+    SR_ONLY_TESTS: "leapp/tests_upgrade_custom_7to8.yml"
+    # SR_ONLY_TESTS: ""
     SR_TEST_LOCAL_CHANGES: true
     SR_PR_NUM: ""
     SR_LSR_USER: ""
@@ -63,20 +108,67 @@ environment:
     SR_ARTIFACTS_URL: ""
     SR_TFT_DEBUG: false
 prepare:
-  - name: Use vault.centos.org repos (CS 7, 8 EOL workaround)
-    # Providing order to run prep tasks as first because beakerlib is required
+  # beaker-harndess contains beaker packages that are required to keep the
+  # machine live when running in beaker
+  - name: Replaces repositories with custom repos
     order: 10
+    when: initiator is not defined and 1minutetip is not defined
     script: |
-      if grep -q 'CentOS Stream release 8' /etc/redhat-release; then
-        sed -i '/^mirror/d;s/#\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo
+      # Backup all repositories
+      if ls /etc/yum.repos.d/*.repo 1>/dev/null 2>&1; then
+        for file in /etc/yum.repos.d/*.repo; do
+          mv "$file" "${file}.backup$(date +%Y%m%d%H%M%S)"
+        done
       fi
-      if grep -q 'CentOS Linux release 7.9' /etc/redhat-release; then
-        sed -i '/^mirror/d;s/#\?\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo
+
+      # Add beaker-harness repository to install beakerlib
+      source /etc/os-release
+      OS_MAJOR_VERSION=${VERSION_ID/%[.]*/}
+      OS_VERSION_UNDERSCORE=$(echo ${VERSION_ID} | sed 's/\./_/g')
+      {
+        echo "[beaker-harness]"
+        echo "baseurl = ${BEAKERLIB_HARNESS_URL_NO_VER}${OS_MAJOR_VERSION}/"
+        echo "enabled = 1"
+        echo "gpgcheck = 0"
+        echo "name = Beaker harness"
+        echo "skip_if_unavailable = 1"
+      } > /etc/yum.repos.d/beaker-harness.repo
+
+      # Configure repositories for RHEL 7
+      # Extras is required to install the leapp package
+      if [ -n "${OS_MAJOR_VERSION}" ] && [ "${OS_MAJOR_VERSION}" -eq 7 ]; then
+        {
+          echo "[rhel-7-server-extras-rpms]"
+          echo "name=RHEL 7 Server Extras"
+          echo "baseurl=${RHEL_7_9_EXTRAS_REPO_URL}"
+          echo "enabled = 1"
+          echo "gpgcheck=0"
+          echo ""
+          echo "[rhel]"
+          echo "name=rhel"
+          echo "baseurl=${RHEL_7_9_SERVER_REPO_URL}"
+          echo "enabled = 1"
+          echo "gpgcheck=0"
+        } > /etc/yum.repos.d/rhel${OS_MAJOR_VERSION}.repo
+        exit
       fi
-  - name: Enable EPEL to get beakerlib
-    order: 10
-    how: feature
-    epel: enabled
+
+      # Configure repositories for RHEL 8+
+      BASEOS_VAR="RHEL_${OS_VERSION_UNDERSCORE}_BASEOS_REPO_URL"
+      APPSTREAM_VAR="RHEL_${OS_VERSION_UNDERSCORE}_APPSTREAM_REPO_URL"
+      {
+        echo "[rhel-${OS_MAJOR_VERSION}-for-x86_64-baseos-rpms]"
+        echo "name=BaseOS for x86_64"
+        echo "baseurl=${!BASEOS_VAR}"
+        echo "enabled = 1"
+        echo "gpgcheck=0"
+        echo ""
+        echo "[rhel-${OS_MAJOR_VERSION}-for-x86_64-appstream-rpms]"
+        echo "name=AppStream for x86_64"
+        echo "baseurl=${!APPSTREAM_VAR}"
+        echo "enabled = 1"
+        echo "gpgcheck=0"
+      } > /etc/yum.repos.d/rhel${OS_MAJOR_VERSION}.repo
 discover:
   - name: Prepare managed node
     how: fmf

--- a/roles/common/tasks/custom_local_repos.yml
+++ b/roles/common/tasks/custom_local_repos.yml
@@ -15,7 +15,7 @@
     gpgcheck: "{{ item.gpgcheck | default(0) }}"
     gpgkey: "{{ item.gpgkey | default(omit) }}"
     repo_gpgcheck: "{{ item.repo_gpgcheck | default(omit) }}"
-    file: "{{ __leapp_repo_file | default(item.file) | default('local') }}"
+    file: "{{ item.file | default(__leapp_repo_file) }}"
     state: "{{ item.state | default('present') }}"
     owner: root
     group: root

--- a/tests/tests_upgrade_custom_7to8.yml
+++ b/tests/tests_upgrade_custom_7to8.yml
@@ -7,25 +7,20 @@
   vars:
     leapp_upgrade_type: custom
     leapp_upgrade_opts: "--no-rhsm"
-    local_repos_pre_leapp: # Install leapp
-      - name: rhel-7-server-extras-rpms
-        description: RHEL 7 Server Extras
-        baseurl: "{{ repo_urls.rhel7.extras.url }}"
-        file: rhel7_extras
-        state: present
     local_repos_leapp:
       - name: rhel-8-for-x86_64-baseos-rpms
         description: BaseOS for x86_64
         baseurl: "{{ repo_urls.rhel8.baseos.url }}"
-        file: /etc/leapp/files/leapp_upgrade_repositories
         state: present
       - name: rhel-8-for-x86_64-appstream-rpms
         description: AppStream for x86_64
         baseurl: "{{ repo_urls.rhel8.appstream.url }}"
-        file: /etc/leapp/files/leapp_upgrade_repositories
         state: present
     title_map: "{{ common_title_map }}"
     leapp_answerfile: "{{ common_leapp_answerfile }}"
+    # This repo is created in prepare phase in plans/test_playbooks.fmf
+    repo_files_to_remove_at_upgrade:
+      - rhel7.repo
   tasks:
     - name: Test | Run upgrade 7to8
       block:
@@ -56,6 +51,12 @@
         - name: Mark upgrade as completed
           ansible.builtin.set_fact:
             leapp_upgrade_completed: true
+
+        - name: Move RHEL repositories to /etc/yum.repos.d/
+          ansible.builtin.command: >-
+            mv /etc/leapp/files/leapp_upgrade_repositories.repo
+            /etc/yum.repos.d/rhel8.repo
+          changed_when: true
       always:
         - name: Cleanup | Remove log files
           tags: tests::cleanup

--- a/tests/tests_upgrade_custom_8to9.yml
+++ b/tests/tests_upgrade_custom_8to9.yml
@@ -11,15 +11,16 @@
       - name: rhel-9-for-x86_64-baseos-rpms
         description: BaseOS for x86_64
         baseurl: "{{ repo_urls.rhel9.baseos.url }}"
-        file: /etc/leapp/files/leapp_upgrade_repositories
         state: present
       - name: rhel-9-for-x86_64-appstream-rpms
         description: AppStream for x86_64
         baseurl: "{{ repo_urls.rhel9.appstream.url }}"
-        file: /etc/leapp/files/leapp_upgrade_repositories
         state: present
     title_map: "{{ common_title_map }}"
     leapp_answerfile: "{{ common_leapp_answerfile }}"
+    # This repo is created in prepare phase in plans/test_playbooks.fmf
+    repo_files_to_remove_at_upgrade:
+      - rhel8.repo
   tasks:
     - name: Test | Run upgrade 8to9
       block:
@@ -50,6 +51,12 @@
         - name: Mark upgrade as completed
           ansible.builtin.set_fact:
             leapp_upgrade_completed: true
+
+        - name: Move RHEL repositories to /etc/yum.repos.d/
+          ansible.builtin.command: >-
+            mv /etc/leapp/files/leapp_upgrade_repositories.repo
+            /etc/yum.repos.d/rhel9.repo
+          changed_when: true
       always:
         - name: Cleanup | Remove log files
           tags: tests::cleanup

--- a/tests/tests_upgrade_custom_9to10.yml
+++ b/tests/tests_upgrade_custom_9to10.yml
@@ -11,15 +11,16 @@
       - name: rhel-10-for-x86_64-baseos-rpms
         description: BaseOS for x86_64
         baseurl: "{{ repo_urls.rhel10.baseos.url }}"
-        file: /etc/leapp/files/leapp_upgrade_repositories
         state: present
       - name: rhel-10-for-x86_64-appstream-rpms
         description: AppStream for x86_64
         baseurl: "{{ repo_urls.rhel10.appstream.url }}"
-        file: /etc/leapp/files/leapp_upgrade_repositories
         state: present
     title_map: "{{ common_title_map }}"
     leapp_answerfile: "{{ common_leapp_answerfile }}"
+    # This repo is created in prepare phase in plans/test_playbooks.fmf
+    repo_files_to_remove_at_upgrade:
+      - rhel9.repo
   tasks:
     - name: Test | Run upgrade 9to10
       block:
@@ -50,6 +51,12 @@
         - name: Mark upgrade as completed
           ansible.builtin.set_fact:
             leapp_upgrade_completed: true
+
+        - name: Move RHEL repositories to /etc/yum.repos.d/
+          ansible.builtin.command: >-
+            mv /etc/leapp/files/leapp_upgrade_repositories.repo
+            /etc/yum.repos.d/rhel10.repo
+          changed_when: true
       always:
         - name: Cleanup | Remove log files
           tags: tests::cleanup

--- a/tests/tmt/prep_managed_node/prep_managed_node.sh
+++ b/tests/tmt/prep_managed_node/prep_managed_node.sh
@@ -24,6 +24,8 @@ rlJournalStart
             fi
         done
         is_virtual=$(lsrIsVirtual)
+        # Remove beaker-harness repository added in the test plan prepare phase
+        rlRun "rm -rf /etc/yum.repos.d/beaker-harness.repo"
         if [ "$is_virtual" -eq 0 ]; then
             lsrDistributeSSHKeys
         fi

--- a/tests/vars/common_upgrade_vars.yml
+++ b/tests/vars/common_upgrade_vars.yml
@@ -31,4 +31,11 @@ common_title_map:
 common_leapp_answerfile: |
   [remove_pam_pkcs11_module_check]
   confirm = True
+
+# We test with internal non-production composes (e.g. nightly) that often
+# contain RPMs that are not signed by RH yet
+# Setting these variables makes leapp accept all installed RPMs as signed by RH
+leapp_env_vars:
+  LEAPP_UNSUPPORTED: 1
+  LEAPP_DEVEL_RPMS_ALL_SIGNED: 1
 ...


### PR DESCRIPTION
Fixing collection:                                                                 
                                                                                   
* Fix setting file when configuring yum repositories. Previously, it was           
  hardcoded to __leapp_repo_file                                                   

Fixing tests:                                                                      
                                                                                   
* Add ability to run test plan on local and 1minutetip images provided             
in an environment-file                                                             
* When running test plan locally, configure repositories from an                   
environment file                                                                   
* Set env variables to make leapp accept all installed RPMs as signed              
  LEAPP_UNSUPPORTED=1                                                              
  LEAPP_DEVEL_RPMS_ALL_SIGNED=1                                                    
* Remove beaker-harness on managed nodes to avoid package conflicts                
* Add note about GH workflow run from main                                         
* After upgrade, move RHEL repositories from                                       
  /etc/leapp/files/leapp_upgrade_repositories.repo to /etc/yum.repos.d/            
