### PR TITLE
test: add test for cifs remediation

### DIFF
--- a/changelogs/fragments/add-test-for-cifs-remediation.yml
+++ b/changelogs/fragments/add-test-for-cifs-remediation.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Add a test for the cifs shares remediation.
+
+...

--- a/tests/tasks/common_upgrade_tasks.yml
+++ b/tests/tasks/common_upgrade_tasks.yml
@@ -1,6 +1,23 @@
 ---
 # Common upgrade test tasks that can be included in any upgrade test
 
+- name: common_upgrade_tasks | Gather setup tasks
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/tasks/setup"
+    patterns: "*.yml"
+  register: setup_tasks
+  delegate_to: localhost
+
+- name: common_upgrade_tasks | Do setup tasks
+  ansible.builtin.include_tasks: "{{ setup_task_file }}"
+  loop: "{{ setup_task_files }}"
+  loop_control:
+    loop_var: setup_task_file
+  vars:
+    setup_task_files: "{{ setup_tasks.files | map(attribute='path') | reject('search', reject_pattern) | list }}"
+    reject_pattern: "{{ '/remediate_' if not leapp_test_remediations | d(false) else 'NOMATCH' }}"
+  when: setup_task_files | length > 0
+
 - name: common_upgrade_tasks | Run first analysis
   ansible.builtin.include_role:
     name: infra.leapp.analysis
@@ -28,14 +45,7 @@
     loop_var: inhibitor_title
   vars:
     map_key: "{{ title_map.keys() | select('in', inhibitor_title) | first | default('') }}"
-  when:
-    - not leapp_test_all_remediations | d(false)
-    - map_key != ''
-
-- name: common_upgrade_tasks | Enable all remediations
-  ansible.builtin.set_fact:
-    remediation_todo: "{{ common_title_map.values() | list }}"
-  when: leapp_test_all_remediations | d(false)
+  when: map_key != ''
 
 - name: common_upgrade_tasks | Debug remediation_todo
   ansible.builtin.debug:
@@ -44,6 +54,21 @@
 - name: common_upgrade_tasks | Run remediation
   ansible.builtin.include_role:
     name: infra.leapp.remediate
+
+- name: common_upgrade_tasks | Gather verify remediation tasks
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/tasks/verify"
+    patterns: "remediate_*.yml"
+  when: leapp_test_remediations | d(false)
+  register: verify_remediation_tasks
+  delegate_to: localhost
+
+- name: common_upgrade_tasks | Verify remediations
+  ansible.builtin.include_tasks: "{{ verify_remediation_task_file }}"
+  loop: "{{ verify_remediation_tasks.files | map(attribute='path') | list }}"
+  loop_control:
+    loop_var: verify_remediation_task_file
+  when: leapp_test_remediations | d(false)
 
 - name: common_upgrade_tasks | Flush handlers
   ansible.builtin.meta: flush_handlers
@@ -55,7 +80,11 @@
 - name: common_upgrade_tasks | Flush handlers
   ansible.builtin.meta: flush_handlers
 
+# set leapp_test_upgrade to false in order to test only analysis and remediation
 - name: common_upgrade_tasks | Run upgrade role
   ansible.builtin.include_role:
     name: infra.leapp.upgrade
+  when: leapp_test_upgrade | d(true)
+  tags:
+    - tests::upgrade
 ...

--- a/tests/tasks/setup/remediate_cifs.yml
+++ b/tests/tasks/setup/remediate_cifs.yml
@@ -1,0 +1,6 @@
+# set up the test system to test cifs shares remediation
+---
+- name: setup | remediate_cifs | Add a CIFS share to /etc/fstab
+  ansible.builtin.lineinfile:
+    path: /etc/fstab
+    line: "//127.0.0.1/test_remediate_cifs /mnt/cifs cifs username=test,password=test 0 0"

--- a/tests/tasks/tests_upgrade_custom.yml
+++ b/tests/tasks/tests_upgrade_custom.yml
@@ -38,6 +38,9 @@
           {{ ansible_distribution_version }}
         success_msg: >-
           System successfully upgraded to RHEL {{ rhel_target_ver }}
+      when: leapp_test_upgrade | d(true)
+      tags:
+        - tests::upgrade
 
     - name: tests_upgrade_custom | Mark upgrade as completed
       ansible.builtin.set_fact:

--- a/tests/tasks/verify/remediate_cifs.yml
+++ b/tests/tasks/verify/remediate_cifs.yml
@@ -1,0 +1,11 @@
+# verify the cifs shares remediation
+# verify that lines with "cifs" are commented out
+# verify that there are no lines with "cifs" that are not commented out
+---
+- name: verify | remediate_cifs | Verify the cifs shares remediation
+  ansible.builtin.command: cat /etc/fstab
+  changed_when: false
+  register: cat_fstab
+  failed_when:
+    - cat_fstab.stdout_lines | select("match", "^#.*cifs") | list | length == 0
+    - cat_fstab.stdout_lines | select("match", "^[^#].*cifs") | list | length > 0

--- a/tests/tests_remediations_7to8.yml
+++ b/tests/tests_remediations_7to8.yml
@@ -1,0 +1,24 @@
+---
+- name: Test RHEL 7 to 8 remediations
+  hosts: all
+  vars_files:
+    - vars/common_upgrade_vars.yml
+    - vars/repo_urls.yml
+  vars:
+    leapp_test_upgrade: false
+    leapp_test_remediations: true
+    rhel_base_ver: 7
+    rhel_target_ver: 8
+    local_repos_leapp:
+      - name: rhel-8-for-x86_64-baseos-rpms
+        description: BaseOS for x86_64
+        baseurl: "{{ repo_urls.rhel8.baseos.url }}"
+        state: present
+      - name: rhel-8-for-x86_64-appstream-rpms
+        description: AppStream for x86_64
+        baseurl: "{{ repo_urls.rhel8.appstream.url }}"
+        state: present
+  tasks:
+    - name: Include tests_upgrade_custom playbook
+      ansible.builtin.include_tasks: tasks/tests_upgrade_custom.yml
+...

--- a/tests/tests_remediations_8to9.yml
+++ b/tests/tests_remediations_8to9.yml
@@ -1,0 +1,24 @@
+---
+- name: Test RHEL 8 to 9 remediations
+  hosts: all
+  vars_files:
+    - vars/common_upgrade_vars.yml
+    - vars/repo_urls.yml
+  vars:
+    leapp_test_upgrade: false
+    leapp_test_remediations: true
+    rhel_base_ver: 8
+    rhel_target_ver: 9
+    local_repos_leapp:
+      - name: rhel-9-for-x86_64-baseos-rpms
+        description: BaseOS for x86_64
+        baseurl: "{{ repo_urls.rhel9.baseos.url }}"
+        state: present
+      - name: rhel-9-for-x86_64-appstream-rpms
+        description: AppStream for x86_64
+        baseurl: "{{ repo_urls.rhel9.appstream.url }}"
+        state: present
+  tasks:
+    - name: Include tests_upgrade_custom playbook
+      ansible.builtin.include_tasks: tasks/tests_upgrade_custom.yml
+...

--- a/tests/tests_remediations_9to10.yml
+++ b/tests/tests_remediations_9to10.yml
@@ -1,0 +1,24 @@
+---
+- name: Test RHEL 9 to 10 remediations
+  hosts: all
+  vars_files:
+    - vars/common_upgrade_vars.yml
+    - vars/repo_urls.yml
+  vars:
+    leapp_test_upgrade: false
+    leapp_test_remediations: true
+    rhel_base_ver: 9
+    rhel_target_ver: 10
+    local_repos_leapp:
+      - name: rhel-10-for-x86_64-baseos-rpms
+        description: BaseOS for x86_64
+        baseurl: "{{ repo_urls.rhel10.baseos.url }}"
+        state: present
+      - name: rhel-10-for-x86_64-appstream-rpms
+        description: AppStream for x86_64
+        baseurl: "{{ repo_urls.rhel10.appstream.url }}"
+        state: present
+  tasks:
+    - name: Include tests_upgrade_custom playbook
+      ansible.builtin.include_tasks: tasks/tests_upgrade_custom.yml
+...

--- a/tests/tmt/test_playbooks/test_playbooks.sh
+++ b/tests/tmt/test_playbooks/test_playbooks.sh
@@ -61,7 +61,7 @@ SR_PYTHON_VERSION="${SR_PYTHON_VERSION:-3.12}"
 # SR_SKIP_TAGS
 #   Ansible tags that must be skipped
 [ -n "$SKIP_TAGS" ] && export SR_SKIP_TAGS="$SKIP_TAGS"
-SR_SKIP_TAGS="--skip-tags tests::nvme,tests::infiniband,tests::bootc-e2e"
+SR_SKIP_TAGS="${SR_SKIP_TAGS:---skip-tags tests::nvme,tests::infiniband,tests::bootc-e2e}"
 # SR_TFT_DEBUG
 #   Print output of ansible playbooks to terminal in addition to printing it to logfile
 [ -n "$LSR_TFT_DEBUG" ] && export SR_TFT_DEBUG="$LSR_TFT_DEBUG"


### PR DESCRIPTION
Add a test to trigger and verify the cifs remediation, and test
playbooks for 7to8, 8to9, and 9to10 in order to run remediations
for those cases.

This adds a sort of test framework for doing test setup and test
verify, by adding `tests/tasks/setup/` and `tests/tasks/verify/`
sub-directories with task files for those purposes.  We currently
use it only for doing remediation setup and verify, but I could
imagine using it for other purposes, or adding a `cleanup/`
sub-directory for cleanup tasks.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
