### PR TITLE
Remove dependency on community.general.modprobe module

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -27,7 +27,6 @@ exclude_paths:
 # not being able to pull community.general (not being validated)
 mock_modules:
   - community.general.redhat_subscription
-  - community.general.modprobe
   - community.general.archive
   - community.general.yum_versionlock
   - community.general.rhsm_repository

--- a/changelogs/fragments/312-remove-modprobe-module.yml
+++ b/changelogs/fragments/312-remove-modprobe-module.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Remove the dependency on the community.general.modprobe module.
+...

--- a/roles/remediate/tasks/leapp_loaded_removed_kernel_drivers.yml
+++ b/roles/remediate/tasks/leapp_loaded_removed_kernel_drivers.yml
@@ -25,9 +25,8 @@
             var: unsupported_modules
 
         - name: leapp_loaded_removed_kernel_drivers | Unload unsupported modules
-          community.general.modprobe:
-            name: "{{ item }}"
-            state: absent
+          ansible.builtin.command:
+            cmd: modprobe -r {{ item }}
           loop: "{{ unsupported_modules }}"
           changed_when: unsupported_modules | length > 0
 

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -72,9 +72,10 @@
     "{{ repo_files_to_remove_at_upgrade }}"
   when: leapp_upgrade_type == "custom"
 
-- name: leapp-upgrade | Include rmmod-kernel-modules.yml
-  ansible.builtin.include_tasks: rmmod-kernel-modules.yml
-  loop: "{{ kernel_modules_to_unload_before_upgrade }}"
+- name: leapp-upgrade | Include remove-kernel-modules.yml
+  ansible.builtin.include_tasks: remove-kernel-modules.yml
+  vars:
+    __kernel_modules_to_remove: "{{ kernel_modules_to_unload_before_upgrade | default([]) }}"
 
 - name: leapp-upgrade | Block to rescue leapp failures to collect errors
   block:

--- a/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
@@ -76,9 +76,10 @@
     state: present
   when: leapp_upgrade_type == "custom"
 
-- name: redhat-upgrade-tool-upgrade | Include rmmod-kernel-modules.yml
-  ansible.builtin.include_tasks: rmmod-kernel-modules.yml
-  loop: "{{ kernel_modules_to_unload_before_upgrade }}"
+- name: redhat-upgrade-tool-upgrade | Include remove-kernel-modules.yml
+  ansible.builtin.include_tasks: remove-kernel-modules.yml
+  vars:
+    __kernel_modules_to_remove: "{{ kernel_modules_to_unload_before_upgrade | default([]) }}"
 
 # --cleanup-post removes Red Hat signed RHEL 6 packages and in theory should be safe.
 - name: redhat-upgrade-tool-upgrade | Run redhat-upgrade-tool

--- a/roles/upgrade/tasks/remove-kernel-modules.yml
+++ b/roles/upgrade/tasks/remove-kernel-modules.yml
@@ -1,0 +1,16 @@
+---
+- name: remove-kernel-modules | Get names of loaded kernel modules
+  ansible.builtin.command:
+    cmd: awk '{print $1}' /proc/modules
+  register: loaded_kernel_modules
+  changed_when: false
+
+- name: remove-kernel-modules | Remove specified kernel modules
+  ansible.builtin.command:
+    cmd: modprobe -r {{ kernel_module }}
+  changed_when: true
+  loop: "{{ __kernel_modules_to_remove | list }}"
+  loop_control:
+    loop_var: kernel_module
+  when: kernel_module in loaded_kernel_modules.stdout_lines
+...

--- a/roles/upgrade/tasks/rmmod-kernel-modules.yml
+++ b/roles/upgrade/tasks/rmmod-kernel-modules.yml
@@ -1,7 +1,0 @@
----
-- name: rmmod-kernel-modules | Unload module {{ item }}
-  community.general.modprobe:
-    name: "{{ item }}"
-    state: absent
-
-...


### PR DESCRIPTION
In order to test it simply add the following into the execution (I've tried 8to9 already)

```
kernel_modules_to_unload_before_upgrade:
      - "joydev"
      - "ahci"
```
Jira: RHEL-134414