### PR TITLE
Prefix variables from defaults/main.yml with `leapp_` for consistency

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -86,6 +86,7 @@ warn_list:
   - risky-file-permissions # File permissions unset or incorrect.
   - template-instead-of-copy # Templated files should use template instead of copy
   - sanity[cannot-ignore] # cope with shebang test bug
+  - jinja[spacing] # Jinja spacing warnings that rarely provide helpful information
 
 # Some rules can transform files to fix (or make it easier to fix) identified
 # errors. `ansible-lint --fix` will reformat YAML files and run these transforms.

--- a/changelogs/fragments/rename-variables.yml
+++ b/changelogs/fragments/rename-variables.yml
@@ -1,0 +1,5 @@
+---
+deprecated_features:
+  - Rename variables of ALL roles in the collection to prefix them with __leapp_ to avoid conflicts with other roles. Older variables names are deprecated and will be removed in a future release.
+
+...

--- a/playbooks/analysis.yml
+++ b/playbooks/analysis.yml
@@ -7,9 +7,9 @@
   force_handlers: true
 
   vars:
-    satellite_organization: My Satellite Organization
-    satellite_activation_key_pre_leapp: MY_ACTIVATION_KEY_PRE
-    satellite_activation_key_leapp: MY_ACTIVATION_KEY
+    leapp_satellite_organization: My Satellite Organization
+    leapp_satellite_activation_key_pre_leapp: MY_ACTIVATION_KEY_PRE
+    leapp_satellite_activation_key_leapp: MY_ACTIVATION_KEY
     # By default the analysis role will use:
     # analysis_repos_el7: rhel-7-server-extras-rpms
     # Optionally override the default analysis_repos_el7 to use the upstream copr leapp repository:

--- a/playbooks/remediate.yml
+++ b/playbooks/remediate.yml
@@ -5,7 +5,7 @@
   become: true
   force_handlers: true
   vars:
-    remediation_todo:
+    leapp_remediation_todo:
       - leapp_firewalld_allowzonedrifting
       - leapp_missing_pkg
   tasks:

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -5,12 +5,12 @@
   become: true
   force_handlers: true
   vars:
-    satellite_organization: My Satellite Organization
-    satellite_activation_key_leapp: MY_ACTIVATION_KEY
-    satellite_activation_key_post_leapp: MY_ACTIVATION_KEY_POST
+    leapp_satellite_organization: My Satellite Organization
+    leapp_satellite_activation_key_leapp: MY_ACTIVATION_KEY
+    leapp_satellite_activation_key_post_leapp: MY_ACTIVATION_KEY_POST
     leapp_upgrade_opts: --target 8.10
-    update_grub_to_grub_2: true
-    selinux_mode: permissive
+    leapp_update_grub_to_grub_2: true
+    leapp_selinux_mode: permissive
   tasks:
     - name: Perform OS upgrade
       ansible.builtin.import_role:

--- a/roles/analysis/README.md
+++ b/roles/analysis/README.md
@@ -18,9 +18,9 @@ Activation keys provide a method to identify content views available from Red Ha
 
 | Name                  | Type | Default value           | Description                                     |
 |-----------------------|------|-------------------------|-------------------------------------------------|
-| satellite_organization  | String   |  | Organization used in Satellite definition |
-| satellite_activation_key_pre_leapp | String |  | Activation key for the current RHEL version content view |
-| satellite_activation_key_leapp     | String |  | Activation key for the content view including both the current RHEL version and the next version |
+| leapp_satellite_organization  | String   | null | Organization used in Satellite definition |
+| leapp_satellite_activation_key_pre_leapp | String | null | Activation key for the current RHEL version content view |
+| leapp_satellite_activation_key_leapp     | String | null | Activation key for the content view including both the current RHEL version and the next version |
 | leapp_repos_enabled    | List | [] | Satellite repo for the satellite client RPM install |
 
 ## Custom repos variables
@@ -29,9 +29,9 @@ See comments in defaults/main.yml for additional details.
 
 | Name                  | Type | Default value           | Description                                     |
 |-----------------------|------|-------------------------|-------------------------------------------------|
-| local_repos_pre_leapp  | List of dicts   | [] | Used to configure repos before running leapp analysis / installing leapp packages.|
-| local_repos_leapp  | List of dicts   | [] | Used to configure next version repos in /etc/leapp/files/leapp_upgrade_repositories.repo. |
-| local_repos_post_analysis  | List of dicts   | [] | Used to return repos to previous state after leapp analysis if necessary. |
+| leapp_local_repos_pre  | List of dicts   | [] | Used to configure repos before running leapp analysis / installing leapp packages.|
+| leapp_local_repos  | List of dicts   | [] | Used to configure next version repos in /etc/leapp/files/leapp_upgrade_repositories.repo. |
+| leapp_local_repos_post_analysis  | List of dicts   | [] | Used to return repos to previous state after leapp analysis if necessary. |
 
 ## Optional variables
 
@@ -42,9 +42,10 @@ See comments in defaults/main.yml for additional details.
 | leapp_high_sev_as_inhibitors | Boolean | False | Treat all high severity findings as inhibitors. |
 | leapp_known_inhibitors | List | [] | List of keys of known inhibitors ignored when setting upgrade_inhibited and leapp_inhibitors. |
 | leapp_env_vars | Dict | {} | Environment variables to use when running `leapp` command. See defaults/main.yml for example. |
-| os_path | String | $PATH | Option string to override the $PATH variable used on the target node |
-| async_timeout_maximum   | Int | 7200                  | Variable used to set the asynchronous task timeout value (in seconds) |
-| async_poll_interval     | Int | 60                    | Variable used to set the asynchronous task polling internal value (in seconds) |
+| leapp_os_path | String | $PATH | Option string to override the $PATH variable used on the target node |
+| leapp_async_timeout_maximum   | Int | 7200                  | Variable used to set the asynchronous task timeout value (in seconds) |
+| leapp_async_poll_interval     | Int | 60                    | Variable used to set the asynchronous task polling internal value (in seconds) |
+| leapp_bypass_fs_checks | Boolean | false | Set to `true` to bypass filesystem capacity checks |
 
 ## Example playbook
 

--- a/roles/analysis/defaults/main.yml
+++ b/roles/analysis/defaults/main.yml
@@ -1,41 +1,71 @@
 ---
 # defaults file for analysis
-analysis_packages_el6:
-  - preupgrade-assistant
-  - preupgrade-assistant-el6toel7
-  - redhat-upgrade-tool
-  - openscap
-  - openscap-engine-sce
+# analysis_packages_el6 is deprecated, use leapp_analysis_packages_el6 instead
+# leapp_analysis_packages_el6:
+#   - preupgrade-assistant
+#   - preupgrade-assistant-el6toel7
+#   - redhat-upgrade-tool
+#   - openscap
+#   - openscap-engine-sce
+leapp_analysis_packages_el6: "{{ analysis_packages_el6 | default([
+  'preupgrade-assistant',
+  'preupgrade-assistant-el6toel7',
+  'redhat-upgrade-tool',
+  'openscap',
+  'openscap-engine-sce'
+]) }}"
 
-analysis_packages_el7:
-  # TODO: Seems to cause package dependency problems with post upgrade cleanup.
-  # - leapp-upgrade-el7toel8
-  # Try this instead.
-  - leapp-upgrade
+# analysis_packages_el7 is deprecated, use leapp_analysis_packages_el7 instead
+# leapp_analysis_packages_el7:
+#   TODO: Seems to cause package dependency problems with post upgrade cleanup.
+#   - leapp-upgrade-el7toel8
+#   Try this instead.
+#   - leapp-upgrade
+leapp_analysis_packages_el7: "{{ analysis_packages_el7 | default([
+  'leapp-upgrade'
+]) }}"
+# analysis_packages_el8 is deprecated, use leapp_analysis_packages_el8 instead
+# leapp_analysis_packages_el8:
+#   TODO: Seems to cause package dependency problems with post upgrade cleanup.
+#   - leapp-upgrade-el8toel9
+#   Try this instead.
+#   - leapp-upgrade
+#   TODO: This should be part of inhibitor remediation.
+#   - vdo
+#   TODO: only w/ rhui for aws
+#   - leapp-rhui-aws
+leapp_analysis_packages_el8: "{{ analysis_packages_el8 | default([
+  'leapp-upgrade'
+]) }}"
+# analysis_packages_el9 is deprecated, use leapp_analysis_packages_el9 instead
+# leapp_analysis_packages_el9:
+#   - leapp-upgrade
+leapp_analysis_packages_el9: "{{ analysis_packages_el9 | default([
+  'leapp-upgrade'
+]) }}"
 
-analysis_packages_el8:
-  # TODO: Seems to cause package dependency problems with post upgrade cleanup.
-  # - leapp-upgrade-el8toel9
-  # Try this instead.
-  - leapp-upgrade
-  # TODO: This should be part of inhibitor remediation.
-  # - vdo
-  # TODO: only w/ rhui for aws
-  # - leapp-rhui-aws
+# analysis_repos_el6 is deprecated, use leapp_analysis_repos_el6 instead
+# leapp_analysis_repos_el6:
+#   - rhel-6-server-extras-rpms
+#   - rhel-6-server-optional-rpms
+leapp_analysis_repos_el6: "{{ analysis_repos_el6 | default([
+  'rhel-6-server-extras-rpms',
+  'rhel-6-server-optional-rpms'
+]) }}"
+# analysis_repos_el7 is deprecated, use leapp_analysis_repos_el7 instead
+# leapp_analysis_repos_el7:
+#   - rhel-7-server-extras-rpms
+leapp_analysis_repos_el7: "{{ analysis_repos_el7 | default([
+  'rhel-7-server-extras-rpms'
+]) }}"
 
-analysis_packages_el9:
-  - leapp-upgrade
+# analysis_repos_el8 is deprecated, use leapp_analysis_repos_el8 instead
+# leapp_analysis_repos_el8: []
+leapp_analysis_repos_el8: "{{ analysis_repos_el8 | default([]) }}"
 
-analysis_repos_el6:
-  - rhel-6-server-extras-rpms
-  - rhel-6-server-optional-rpms
-
-analysis_repos_el7:
-  - rhel-7-server-extras-rpms
-
-analysis_repos_el8: []
-
-analysis_repos_el9: []
+# analysis_repos_el9 is deprecated, use leapp_analysis_repos_el9 instead
+# leapp_analysis_repos_el9: []
+leapp_analysis_repos_el9: "{{ analysis_repos_el9 | default([]) }}"
 
 # If defined, leapp_answerfile will be used as the contents of /var/log/leapp/answerfile.
 # leapp_answerfile: |
@@ -51,13 +81,13 @@ leapp_preupg_opts: "{{ '--no-rhsm' if leapp_upgrade_type == 'rhui' or leapp_upgr
 
 # Satellite Organization and Activation Keys are required if using Satellite to change content views
 # unless the content view already in use has all required repositories.
-# satellite_organization: Example
-# satellite_activation_key_pre_leapp: rhel{{ ansible_distribution_major_version }}
-# satellite_activation_key_leapp: rhel{{ ansible_distribution_major_version }}_leapp
+leapp_satellite_organization: null
+leapp_satellite_activation_key_pre_leapp: null
+leapp_satellite_activation_key_leapp: null
 
-leapp_repos_enabled: []
 # leapp_repos_enabled:
 #   - satellite-client-6-for-rhel-{{ ansible_distribution_major_version | int + 1 }}-x86_64-rpms
+leapp_repos_enabled: []
 
 # Treat all high risk findings as inhibitors, not just those exclusively marked as inhibitors by Leapp
 leapp_high_sev_as_inhibitors: false
@@ -74,90 +104,105 @@ leapp_env_vars: {}
 
 # For leapp_upgrade_type == "custom"
 # Used to configure repos before running leapp analysis / installing leapp packages.
-local_repos_pre_leapp: []
-# local_repos_pre_leapp:
+# local_repos_pre_leapp is deprecated, use leapp_local_repos_pre instead
+# leapp_local_repos_pre: []
+leapp_local_repos_pre: "{{ local_repos_pre_leapp | default([]) }}"
+# leapp_local_repos_pre:
 #   - name: rhel-server-7-rpms
 #     description: Red Hat 7 Server
 #     baseurl: http://repo02.example.com/leapp/7Server/rhel-server-7-rpms
-#     # enabled: 1 # Default 1
-#     # gpgcheck: 0 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
-#     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
-#     # state: present # Defaults to present
+#     enabled: 1 # Default 1
+#     gpgcheck: 0 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
+#     file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
+#     state: present # Defaults to present
 #   - name: rhel-server-7-rpms
 #     description: Red Hat 7 Server
 #     baseurl: http://repo02.example.com/leapp/7Server/rhel-server-7-rpms
-#     # enabled: 1 # Default 1
-#     # gpgcheck: 0 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
-#     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
-#     # state: present # Defaults to present
+#     enabled: 1 # Default 1
+#     gpgcheck: 0 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
+#     file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
+#     state: present # Defaults to present
 
 # For leapp_upgrade_type == "custom"
 # Used to generate /etc/leapp/files/leapp_upgrade_repositories.repo
 # Generated using ansible.builtin.yum_repository.
-local_repos_leapp: []
-# local_repos_leapp:
+# local_repos_leapp is deprecated, use leapp_local_repos instead
+# leapp_local_repos: []
+leapp_local_repos: "{{ local_repos_leapp | default([]) }}"
+# leapp_local_repos:
 #   - name: rhel-8-for-x86_64-baseos-rpms
 #     description: Red Hat 8.10 Base OS
 #     baseurl: http://repo01.example.com/8.10/rhel-8-for-x86_64-baseos-rpms
-#     # enabled: 1 # Default 1
-#     # gpgcheck: 0 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
+#     enabled: 1 # Default 1
+#     gpgcheck: 0 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
 #   - name: rhel-8-for-x86_64-appstream-rpms
 #     description: Red Hat 8.10 App Stream
 #     baseurl: http://repo01.example.com/8.10/rhel-8-for-x86_64-baseos-rpms
-#     # enabled: 1 # Default 1
-#     # gpgcheck: 0 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
+#     enabled: 1 # Default 1
+#     gpgcheck: 0 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
 
 # For leapp_upgrade_type == "custom"
 # Used to return repos to previous state after leapp analysis if necessary.
-local_repos_post_analysis: []
-# local_repos_post_analysis:
+# local_repos_post_analysis is deprecated, use leapp_local_repos_post_analysis instead
+# leapp_local_repos_post_analysis: []
+leapp_local_repos_post_analysis: "{{ local_repos_post_analysis | default([]) }}"
+# leapp_local_repos_post_analysis:
 #   - name: rhel-server-7-rpms
 #     description: Red Hat 7 Server
 #     baseurl: http://repo02.example.com/leapp/7Server/rhel-server-7-rpms
-#     # enabled: 1 # Default 1
-#     # gpgcheck: 0 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
-#     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
+#     enabled: 1 # Default 1
+#     gpgcheck: 0 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
+#     file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
 #     state: absent # Defaults to present
 #   - name: rhel-server-7-rpms
 #     description: Red Hat 7 Server
 #     baseurl: http://repo02.example.com/leapp/7Server/rhel-server-7-rpms
-#     # enabled: 1 # Default 1
-#     # gpgcheck: 0 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
-#     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
+#     enabled: 1 # Default 1
+#     gpgcheck: 0 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
+#     file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
 #     state: absent # Defaults to present
 #   - name: rhel-server-7-rpms
 #     description: Red Hat 7 Server
 #     baseurl: http://repo01.example.com/7Server/rhel-server-7-rpms
-#     # enabled: 1 # Default 1
-#     # gpgcheck: 0 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
-#     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
-#     # state: present # Defaults to present
+#     enabled: 1 # Default 1
+#     gpgcheck: 0 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
+#     file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
+#     state: present # Defaults to present
 #   - name: rhel-server-7-rpms
 #     description: Red Hat 7 Server
 #     baseurl: http://repo01.example.com/7Server/rhel-server-7-rpms
-#     # enabled: 1 # Default 1
-#     # gpgcheck: 0 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
-#     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
-#     # state: present # Defaults to present
+#     enabled: 1 # Default 1
+#     gpgcheck: 0 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
+#     file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
+#     state: present # Defaults to present
 
-os_path: $PATH
+# os_path is deprecated, use leapp_os_path instead
+# leapp_os_path: $PATH
+leapp_os_path: "{{ os_path | default('$PATH') }}"
 
-async_timeout_maximum: 7200
-async_poll_interval: 60
+# async_timeout_maximum is deprecated, use leapp_async_timeout_maximum instead
+# leapp_async_timeout_maximum: 7200
+leapp_async_timeout_maximum: "{{ async_timeout_maximum | default(7200) }}"
+
+# async_poll_interval is deprecated, use leapp_async_poll_interval instead
+# leapp_async_poll_interval: 60
+leapp_async_poll_interval: "{{ async_poll_interval | default(60) }}"
+
+leapp_bypass_fs_checks: false
 ...

--- a/roles/analysis/handlers/main.yml
+++ b/roles/analysis/handlers/main.yml
@@ -3,21 +3,21 @@
 - name: Register to pre leapp activation key
   community.general.redhat_subscription:
     state: present
-    activationkey: "{{ satellite_activation_key_pre_leapp }}"
-    org_id: "{{ satellite_organization }}"
+    activationkey: "{{ leapp_satellite_activation_key_pre_leapp }}"
+    org_id: "{{ leapp_satellite_organization }}"
     force_register: true
   when:
     - leapp_upgrade_type == 'satellite'
-    - satellite_organization is defined
-    - satellite_activation_key_pre_leapp is defined
+    - leapp_satellite_organization is not none
+    - leapp_satellite_activation_key_pre_leapp is not none
 
 # TODO: Having issues with community.general.redhat_subscription and subscription-manager on RHEL 6.
 - name: Register to pre leapp activation key RHEL 6
   ansible.builtin.shell: >
-    export PATH={{ os_path }};
+    export PATH={{ leapp_os_path }};
     subscription-manager register
-    --org="{{ satellite_organization }}"
-    --activationkey="{{ satellite_activation_key_pre_leapp }}"
+    --org="{{ leapp_satellite_organization }}"
+    --activationkey="{{ leapp_satellite_activation_key_pre_leapp }}"
     --force
   register: sub_man_reg
   changed_when: true
@@ -50,6 +50,6 @@
     msg: >-
       The preupgrade analysis report generation is now complete.
       {{ 'WARNING: Inhibitors' if upgrade_inhibited else 'SUCCESS: No inhibitors' }} found.
-      Review the tasks above or the result file at {{ result_filename }}.
+      Review the tasks above or the result file at {{ leapp_result_filename }}.
 
 ...

--- a/roles/analysis/tasks/analysis-leapp.yml
+++ b/roles/analysis/tasks/analysis-leapp.yml
@@ -2,18 +2,18 @@
 - name: analysis-leapp | Register to leapp activation key
   community.general.redhat_subscription:
     state: present
-    activationkey: "{{ satellite_activation_key_leapp }}"
-    org_id: "{{ satellite_organization }}"
+    activationkey: "{{ leapp_satellite_activation_key_leapp }}"
+    org_id: "{{ leapp_satellite_organization }}"
     force_register: true
   notify: Register to pre leapp activation key
   when:
     - leapp_upgrade_type == 'satellite'
-    - satellite_organization is defined
-    - satellite_activation_key_leapp is defined
+    - leapp_satellite_organization is not none
+    - leapp_satellite_activation_key_leapp is not none
 
 - name: analysis-leapp | Include custom_local_repos for local_repos_pre_leapp
   vars:
-    __repos: "{{ local_repos_pre_leapp }}"
+    __repos: "{{ leapp_local_repos_pre }}"
   ansible.builtin.include_role:
     name: infra.leapp.common
     tasks_from: custom_local_repos
@@ -21,22 +21,22 @@
 
 - name: analysis-leapp | Install packages for preupgrade analysis on RHEL 7
   ansible.builtin.package:
-    name: "{{ analysis_packages_el7 }}"
-    enablerepo: "{{ analysis_repos_el7 }}"
+    name: "{{ leapp_analysis_packages_el7 }}"
+    enablerepo: "{{ leapp_analysis_repos_el7 }}"
     state: latest # noqa package-latest
   when: ansible_distribution_major_version|int == 7
 
 - name: analysis-leapp | Install packages for preupgrade analysis on RHEL 8
   ansible.builtin.package:
-    name: "{{ analysis_packages_el8 }}"
-    enablerepo: "{{ analysis_repos_el8 }}"
+    name: "{{ leapp_analysis_packages_el8 }}"
+    enablerepo: "{{ leapp_analysis_repos_el8 }}"
     state: latest # noqa package-latest
   when: ansible_distribution_major_version|int == 8
 
 - name: analysis-leapp | Install packages for preupgrade analysis on RHEL 9
   ansible.builtin.package:
-    name: "{{ analysis_packages_el9 }}"
-    enablerepo: "{{ analysis_repos_el9 }}"
+    name: "{{ leapp_analysis_packages_el9 }}"
+    enablerepo: "{{ leapp_analysis_repos_el9 }}"
     state: latest # noqa package-latest
   when: ansible_distribution_major_version|int == 9
 
@@ -59,36 +59,36 @@
 
 - name: analysis-leapp | Create /etc/leapp/files/leapp_upgrade_repositories.repo
   vars:
-    __repos: "{{ local_repos_leapp }}"
+    __repos: "{{ leapp_local_repos }}"
     __leapp_repo_file: /etc/leapp/files/leapp_upgrade_repositories
   ansible.builtin.include_role:
     name: infra.leapp.common
     tasks_from: custom_local_repos
   when:
     - leapp_upgrade_type == 'custom'
-    - local_repos_leapp | length > 0
+    - leapp_local_repos | length > 0
 
 - name: analysis-leapp | Leapp preupgrade report
   ansible.builtin.shell: >
     set -o pipefail;
-    export PATH={{ os_path }};
+    export PATH={{ leapp_os_path }};
     ulimit -n 16384;
     leapp preupgrade --report-schema=1.2.0
     {{ leapp_preupg_opts }}
-    {{ leapp_enable_repos_args }}
-    2>&1 | tee -a {{ log_file }}
+    {{ __leapp_enable_repos_args }}
+    2>&1 | tee -a {{ leapp_log_file }}
   environment: "{{ leapp_env_vars }}"
   changed_when: true
   register: leapp
   args:
     executable: /bin/bash
-  async: "{{ async_timeout_maximum | int }}"
-  poll: "{{ async_poll_interval | int }}"
+  async: "{{ leapp_async_timeout_maximum | int }}"
+  poll: "{{ leapp_async_poll_interval | int }}"
   failed_when: "'report has been generated' not in leapp.stdout"
 
 - name: analysis-leapp | Include custom_local_repos for local_repos_post_analysis
   vars:
-    __repos: "{{ local_repos_post_analysis }}"
+    __repos: "{{ leapp_local_repos_post_analysis }}"
   ansible.builtin.include_role:
     name: infra.leapp.common
     tasks_from: custom_local_repos

--- a/roles/analysis/tasks/analysis-preupg.yml
+++ b/roles/analysis/tasks/analysis-preupg.yml
@@ -2,15 +2,15 @@
 # TODO: Having issues with community.general.redhat_subscription and subscription-manager on RHEL 6.
 - name: analysis-preupg | Register to upgrade activation key
   ansible.builtin.shell: >
-    export PATH={{ os_path }};
+    export PATH={{ leapp_os_path }};
     subscription-manager register
-    --org="{{ satellite_organization }}"
-    --activationkey="{{ satellite_activation_key_pre_leapp }}"
+    --org="{{ leapp_satellite_organization }}"
+    --activationkey="{{ leapp_satellite_activation_key_pre_leapp }}"
     --force
   when:
     - leapp_upgrade_type == 'satellite'
-    - satellite_organization is defined
-    - satellite_activation_key_pre_leapp is defined
+    - leapp_satellite_organization is not none
+    - leapp_satellite_activation_key_pre_leapp is not none
   notify: Register to pre leapp activation key RHEL 6
   register: sub_man_reg
   failed_when: false
@@ -18,7 +18,7 @@
 
 - name: analysis-preupg | Include custom_local_repos for local_repos_pre_leapp
   vars:
-    __repos: "{{ local_repos_pre_leapp }}"
+    __repos: "{{ leapp_local_repos_pre }}"
   ansible.builtin.include_role:
     name: infra.leapp.common
     tasks_from: custom_local_repos
@@ -27,23 +27,23 @@
 - name: analysis-preupg | Enable requisite RHUI repos
   ansible.builtin.shell: |
     set -o pipefail;
-    export PATH={{ os_path }};
+    export PATH={{ leapp_os_path }};
     yum-config-manager --enable {{ item }}
-  loop: "{{ analysis_repos_el6 }}"
+  loop: "{{ leapp_analysis_repos_el6 }}"
   when: leapp_upgrade_type == 'rhui'
   failed_when: false
   changed_when: true
 
 - name: analysis-preupg | Preupgrade Assistant and Red Hat Upgrade Tool packages are latest
   ansible.builtin.package:
-    name: "{{ analysis_packages_el6 }}"
-    enablerepo: "{{ analysis_repos_el6 }}"
+    name: "{{ leapp_analysis_packages_el6 }}"
+    enablerepo: "{{ leapp_analysis_repos_el6 }}"
     state: latest # noqa package-latest
   when: leapp_upgrade_type != 'rhui'
 
 - name: analysis-preupg | Preupgrade Assistant and Red Hat Upgrade Tool packages are latest - RHUI
   ansible.builtin.package:
-    name: "{{ analysis_packages_el6 }}"
+    name: "{{ leapp_analysis_packages_el6 }}"
     state: latest # noqa package-latest
   when: leapp_upgrade_type == 'rhui'
 
@@ -56,30 +56,30 @@
 - name: analysis-preupg | Filesystem capacity checks
   ansible.builtin.script: check-inodes.sh
   changed_when: false
-  when: bypass_fs_checks is not defined or (bypass_fs_checks is defined and bypass_fs_checks | lower != 'yes')
+  when: not leapp_bypass_fs_checks
 
 - name: analysis-preupg | Run preupg
   ansible.builtin.shell: >
     set -o pipefail;
-    export PATH={{ os_path }};
+    export PATH={{ leapp_os_path }};
     preupg --force --text
-    2>&1 | tee -a {{ log_file }}
+    2>&1 | tee -a {{ leapp_log_file }}
   register: preupg
   args:
     executable: /bin/bash
-  async: "{{ async_timeout_maximum | int }}"
-  poll: "{{ async_poll_interval | int }}"
+  async: "{{ leapp_async_timeout_maximum | int }}"
+  poll: "{{ leapp_async_poll_interval | int }}"
   failed_when: false
   changed_when: true
 
 - name: analysis-preupg | Assert that preupg did not encounter errors
   ansible.builtin.assert:
-    that: not preupg_return_codes[preupg.rc].fail
-    msg: "{{ preupg_return_codes[preupg.rc].msg }}"
+    that: not __leapp_preupg_return_codes[preupg.rc].fail
+    msg: "{{ __leapp_preupg_return_codes[preupg.rc].msg }}"
 
 - name: analysis-preupg | Include custom_local_repos for local_repos_post_analysis
   vars:
-    __repos: "{{ local_repos_post_analysis }}"
+    __repos: "{{ leapp_local_repos_post_analysis }}"
   ansible.builtin.include_role:
     name: infra.leapp.common
     tasks_from: custom_local_repos
@@ -90,7 +90,7 @@
 
 - name: analysis-preupg | Collect human readable report results
   ansible.builtin.slurp:
-    src: "{{ result_filename }}"
+    src: "{{ leapp_result_filename }}"
   register: results
 
 - name: analysis-preupg | Parse report results
@@ -99,21 +99,21 @@
 
 - name: analysis-preupg | Check for inhibitors
   ansible.builtin.set_fact:
-    upgrade_inhibited: "{{ preupg_return_codes[preupg.rc].inhibited }}"
+    upgrade_inhibited: "{{ __leapp_preupg_return_codes[preupg.rc].inhibited }}"
 
 # We already have preupg_report_txt that has this info in it.
 # However, this makes it work the same as leapp which is using
 # some awk magic to parse the file.
 - name: analysis-preupg | Collect inhibitors
   ansible.builtin.command:
-    cmd: grep "preupg.risk.EXTREME:" {{ result_filename }}
+    cmd: grep "preupg.risk.EXTREME:" {{ leapp_result_filename }}
   register: results_inhibitors
   changed_when: false
   failed_when: false
 
 - name: analysis-preupg | Collect high errors
   ansible.builtin.command:
-    cmd: egrep -i "preupg.risk.HIGH:.*not enough free space" {{ result_filename }}
+    cmd: egrep -i "preupg.risk.HIGH:.*not enough free space" {{ leapp_result_filename }}
   register: results_errors
   changed_when: false
   failed_when: false

--- a/roles/analysis/tasks/check-results-file.yml
+++ b/roles/analysis/tasks/check-results-file.yml
@@ -1,12 +1,12 @@
 ---
 - name: check-results-file | Result file status
   ansible.builtin.stat:
-    path: "{{ result_filename }}"
+    path: "{{ leapp_result_filename }}"
   register: result
 
 - name: check-results-file | Check that result file exists
   ansible.builtin.assert:
     that: result.stat.exists
-    msg: The preupgrade analysis report file {{ result_filename }} was not created.
+    msg: The preupgrade analysis report file {{ leapp_result_filename }} was not created.
 
 ...

--- a/roles/analysis/vars/main.yml
+++ b/roles/analysis/vars/main.yml
@@ -1,11 +1,10 @@
 ---
 # vars file for analysis
-leapp_enable_repos_args: "{{ ('--enablerepo ' + leapp_repos_enabled | default([], true) | join(' --enablerepo '))
+__leapp_enable_repos_args: "{{ ('--enablerepo ' + leapp_repos_enabled | default([], true) | join(' --enablerepo '))
   if leapp_repos_enabled | length > 0 else '' }}"
 
-result_filename: "{{ '/root/preupgrade/result.txt' if ansible_distribution_major_version == '6'
+leapp_result_filename: "{{ '/root/preupgrade/result.txt' if ansible_distribution_major_version == '6'
   else '/var/log/leapp/leapp-report.txt' }}"
 
 leapp_inhibitors: []
-
 ...

--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -17,19 +17,19 @@ Define job_name in the import as seen below.
 | Name                  | Type | Optional | Default value | Description |
 |-----------------------|------|----------|---------------|-------------------------------------------------|
 | job_name | String | No | None | The string describes the job run |
-| log_directory | DirPath | Yes | "/var/log/ripu" | Directory under which local log files will be written. This directory will be created is it is not already present |
-| log_file | FilePath | Yes | "{{ log_directory }}/ripu.log" | Local log filename. When a playbook job finishes, a timestamp suffix is appended to the end of the specified filename |
+| leapp_log_directory | DirPath | Yes | "/var/log/ripu" | Directory under which local log files will be written. This directory will be created is it is not already present |
+| leapp_log_file | FilePath | Yes | "{{ leapp_log_directory }}/ripu.log" | Local log filename. When a playbook job finishes, a timestamp suffix is appended to the end of the specified filename |
 
 ### Role variables used with parse_leapp_report.yml
 
-**NOTE:** `result_filename` is **REQUIRED**.  The other result_filename* parameters will be derived from it if not explicitly given.
+**NOTE:** `leapp_result_filename` is **REQUIRED**.  The other leapp_result_filename* parameters will be derived from it if not explicitly given.
 
 | Name                         | Type   | Default value                     | Description                                                                      |
 |------------------------------|--------|-----------------------------------|----------------------------------------------------------------------------------|
-| result_filename              | string | /var/log/leapp/leapp-report.txt   | REQUIRED - Path of the Leapp pre-upgrade report file.                            |
-| result_filename_prefix       | string | /var/log/leapp/leapp-report       | The path used and the prefix name setting for the Leapp report                   |
-| result_filename_json         | string | {{ result_filename_prefix }}.json | JSON filename using the selected "result_filename_prefix"                        |
-| result_fact_cacheable        | bool   | false                             | Allow the results from parsing the LEAPP report be cacheable (primarily for AAP) |
+| leapp_result_filename              | string | /var/log/leapp/leapp-report.txt   | REQUIRED - Path of the Leapp pre-upgrade report file.                            |
+| leapp_result_filename_prefix       | string | /var/log/leapp/leapp-report       | The path used and the prefix name setting for the Leapp report                   |
+| leapp_result_filename_json         | string | {{ leapp_result_filename_prefix }}.json | JSON filename using the selected "leapp_result_filename_prefix"                        |
+| leapp_result_fact_cacheable        | bool   | false                             | Allow the results from parsing the LEAPP report be cacheable (primarily for AAP) |
 | leapp_high_sev_as_inhibitors | bool   | false                             | Treat all high severity findings as inhibitors.                                  |
 
 ### Variables exported by parse_leapp_report.yml
@@ -41,8 +41,8 @@ Define job_name in the import as seen below.
 | leapp_report_txt   | list     | List of lines from the text report                     |
 | leapp_report_json  | dict     | The JSON report returned as a dict object              |
 | leapp_inhibitors   | list     | Raw list of inhibitors                                 |
-| results_inhibitors | register | Result of parsing out inhibitors from result_filename  |
-| results_errors     | register | Result of parsing out high errors from result_filename |
+| results_inhibitors | register | Result of parsing out inhibitors from leapp_result_filename  |
+| results_errors     | register | Result of parsing out high errors from leapp_result_filename |
 | upgrade_inhibited  | bool     | true if there are inhibitors blocking upgrade          |
 
 ### How to use parse_leapp_report.yml
@@ -53,8 +53,8 @@ Define job_name in the import as seen below.
     name: infra.leapp.common
     tasks_from: parse_leapp_report.yml
   vars:
-    result_filename: /path/to/something   # if not already defined previously
-    result_fact_cacheable: true  # if not already defined previously
+    leapp_result_filename: /path/to/something   # if not already defined previously
+    leapp_result_fact_cacheable: true  # if not already defined previously
 
 - name: MYTASKNAME | Display inhibitors
   ansible.builtin.debug:
@@ -64,7 +64,7 @@ Define job_name in the import as seen below.
 
 ## Logging
 
-Logs will accumulate in the directory referenced by `log_file`, with a suffixed datestamp upon completion.
+Logs will accumulate in the directory referenced by `leapp_log_file`, with a suffixed datestamp upon completion.
 
 If a log file exists during execution of this role (without suffixed datestamp), execution will terminate as there is an analysis job running already.
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 # defaults file for common
-os_path: $PATH
-log_directory: /var/log/ripu
-log_file: "{{ log_directory }}/ripu.log"
-
+leapp_os_path: $PATH
+leapp_log_directory: /var/log/ripu
+leapp_log_file: "{{ leapp_log_directory }}/ripu.log"
 ...

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -2,13 +2,13 @@
 # handlers file for common
 - name: Check for log file
   ansible.builtin.stat:
-    path: "{{ log_file }}"
+    path: "{{ leapp_log_file }}"
   register: log_file_stat
   listen: Archive log file
 
 - name: Add end time to log file
   ansible.builtin.lineinfile:
-    path: "{{ log_file }}"
+    path: "{{ leapp_log_file }}"
     line: Job ended at {{ now(fmt='%Y-%m-%dT%H:%M:%SZ', utc=true) }}
     owner: root
     group: root
@@ -18,7 +18,7 @@
 
 - name: Slurp ripu.log file
   ansible.builtin.slurp:
-    src: "{{ log_file }}"
+    src: "{{ leapp_log_file }}"
   register: ripu_log_file_slurp
   listen: Archive log file
   when: log_file_stat.stat.exists
@@ -31,8 +31,8 @@
 
 - name: Rename log file
   ansible.builtin.shell: |
-    export PATH={{ os_path }}
-    mv {{ log_file }} {{ log_file }}-{{ ansible_date_time.iso8601_basic_short }}
+    export PATH={{ leapp_os_path }}
+    mv {{ leapp_log_file }} {{ leapp_log_file }}-{{ ansible_date_time.iso8601_basic_short }}
   listen: Archive log file
   changed_when: true
   when: log_file_stat.stat.exists

--- a/roles/common/tasks/custom_local_repos.yml
+++ b/roles/common/tasks/custom_local_repos.yml
@@ -21,6 +21,6 @@
     group: root
     mode: "0644"
   loop: "{{ __repos }}"
-  no_log: true
+  # no_log: true
 
 ...

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for common
 - name: Log directory exists
   ansible.builtin.file:
-    path: "{{ log_directory }}"
+    path: "{{ leapp_log_directory }}"
     state: directory
     owner: root
     group: root
@@ -10,13 +10,13 @@
 
 - name: Check for existing log file
   ansible.builtin.stat:
-    path: "{{ log_file }}"
+    path: "{{ leapp_log_file }}"
   register: log_file_stat
 
 - name: Fail if log file already exists
   ansible.builtin.fail:
     msg: >-
-      Another RIPU playbook job is already running. See {{ log_file }} for details. If the previous job was aborted,
+      Another RIPU playbook job is already running. See {{ leapp_log_file }} for details. If the previous job was aborted,
       rename the log file to clear this failure and try again.
   when: log_file_stat.stat.exists
 
@@ -25,7 +25,7 @@
     content: |
       {{ job_name }}
       Job started at {{ now(fmt='%Y-%m-%dT%H:%M:%SZ', utc=true) }}
-    dest: "{{ log_file }}"
+    dest: "{{ leapp_log_file }}"
     owner: root
     group: root
     mode: "0644"
@@ -52,7 +52,7 @@
   ansible.builtin.shell:
     cmd: >-
       set -o pipefail;
-      export PATH={{ os_path }};
+      export PATH={{ leapp_os_path }};
       rpm -qa | grep -ve '[\.|+]el{{ ansible_distribution_major_version }}' |
       grep -vE '^(gpg-pubkey|libmodulemd|katello-ca-consumer)' |
       sort

--- a/roles/common/tasks/parse_leapp_report.yml
+++ b/roles/common/tasks/parse_leapp_report.yml
@@ -1,13 +1,13 @@
 # Inputs:
-# - result_filename - REQUIRED - path to the Leapp pre-upgrade report file
+# - leapp_result_filename - REQUIRED - path to the Leapp pre-upgrade report file
 ---
 - name: parse_leapp_report | Parse Leapp Report
   vars:
-    result_directory: "{{ result_filename | dirname }}"
-    result_basename: "{{ result_filename | basename | splitext | first }}"
-    result_filename_prefix: "{{ result_directory }}/{{ result_basename }}"
-    result_filename_json: "{{ result_filename_prefix }}.json"
-    result_fact_cacheable: false
+    leapp_result_directory: "{{ leapp_result_filename | dirname }}"
+    leapp_result_basename: "{{ leapp_result_filename | basename | splitext | first }}"
+    leapp_result_filename_prefix: "{{ leapp_result_directory }}/{{ leapp_result_basename }}"
+    leapp_result_filename_json: "{{ leapp_result_filename_prefix }}.json"
+    leapp_result_fact_cacheable: false
   block:
     - name: parse_leapp_report | Default upgrade_inhibited to false
       ansible.builtin.set_fact:
@@ -15,23 +15,23 @@
 
     - name: parse_leapp_report | Collect human readable report results
       ansible.builtin.slurp:
-        src: "{{ result_filename }}"
+        src: "{{ leapp_result_filename }}"
       register: results_txt
 
     - name: parse_leapp_report | Collect JSON report results
       ansible.builtin.slurp:
-        src: "{{ result_filename_json }}"
+        src: "{{ leapp_result_filename_json }}"
       register: results_json
 
     - name: parse_leapp_report | Parse report results
       ansible.builtin.set_fact:
-        cacheable: "{{ result_fact_cacheable }}"
+        cacheable: "{{ leapp_result_fact_cacheable }}"
         leapp_report_txt: "{{ results_txt.content | b64decode | split('\n') }}"
         leapp_report_json: "{{ results_json.content | b64decode | from_json }}"
 
     - name: parse_leapp_report | Check for inhibitors
       ansible.builtin.set_fact:
-        cacheable: "{{ result_fact_cacheable }}"
+        cacheable: "{{ leapp_result_fact_cacheable }}"
         upgrade_inhibited: true
         leapp_inhibitors: "{{ leapp_inhibitors | default([]) + [item] }}"
       when:
@@ -45,14 +45,14 @@
       vars:
         high_filter: "{{ '|Risk Factor: high' if leapp_high_sev_as_inhibitors | default(false, true) | bool else '' }}"
       ansible.builtin.command:
-        cmd: awk '/\(inhibitor\){{ high_filter }}/,/^-------/' {{ result_filename }}
+        cmd: awk '/\(inhibitor\){{ high_filter }}/,/^-------/' {{ leapp_result_filename }}
       register: results_inhibitors
       changed_when: false
       failed_when: false
 
     - name: parse_leapp_report | Collect high errors
       ansible.builtin.command:
-        cmd: awk '/high \(error\)/,/^-------/' {{ result_filename }}
+        cmd: awk '/high \(error\)/,/^-------/' {{ leapp_result_filename }}
       register: results_errors
       changed_when: false
       failed_when: false

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # vars file for common
-preupg_return_codes:
+__leapp_preupg_return_codes:
   0:
     msg: "preupg works properly and modules exit with the following results: PASS, FIXED, INFORMATIONAL, NEEDS_INSPECTION, NOT_APPLICABLE."
     fail: false

--- a/roles/remediate/README.md
+++ b/roles/remediate/README.md
@@ -9,15 +9,16 @@ The `remediation` role is to assist in the remediation of a system. This role co
 | Name                    | Default value         | Description                                         |
 |-------------------------|-----------------------|-----------------------------------------------------|
 | leapp_report_location   | /var/log/leapp/leapp-report.json | Location of the leapp report file.       |
-| remediation_playbooks   | see [Remediation playbooks](#remediation-playbooks) | List of available remediation playbooks.|
-| remediation_todo        | []                    | List of remediation playbooks to run.               |
-| reboot_timeout          | 7200                  | Integer for maximum seconds to wait for reboot to complete.     |
-| post_reboot_delay       | 120                   | Integer to pass to the reboot post_reboot_delay option. |
+| leapp_remediation_playbooks   | see [Remediation playbooks](#remediation-playbooks) | List of available remediation playbooks.|
+| leapp_remediation_todo        | []                    | List of remediation playbooks to run.               |
+| leapp_reboot_timeout          | 7200                  | Integer for maximum seconds to wait for reboot to complete.     |
+| leapp_pre_reboot_delay        | 60                    | Integer to pass to the reboot pre_reboot_delay option. |
+| leapp_post_reboot_delay       | 120                   | Integer to pass to the reboot post_reboot_delay option. |
 
-`remediation_todo` is a list of remediation playbooks to run. The list is empty by default. The list can be populated by the titles from [Remediation playbooks](#remediation-playbooks) section. For example:
+`leapp_remediation_todo` is a list of remediation playbooks to run. The list is empty by default. The list can be populated by the titles from [Remediation playbooks](#remediation-playbooks) section. For example:
 
 ```yaml
-remediation_todo:
+leapp_remediation_todo:
   - leapp_cifs_detected
   - leapp_corrupted_grubenv_file
 ```

--- a/roles/remediate/defaults/main.yml
+++ b/roles/remediate/defaults/main.yml
@@ -1,36 +1,78 @@
 ---
 # defaults file for remedations
 
-reboot_timeout: 7200
-pre_reboot_delay: 60
-post_reboot_delay: 120
+# reboot_timeout is deprecated, use leapp_reboot_timeout instead
+# leapp_reboot_timeout: 7200
+leapp_reboot_timeout: "{{ reboot_timeout | default(7200) }}"
+
+# pre_reboot_delay is deprecated, use leapp_pre_reboot_delay instead
+# leapp_pre_reboot_delay: 60
+leapp_pre_reboot_delay: "{{ pre_reboot_delay | default(60) }}"
+
+# post_reboot_delay is deprecated, use leapp_post_reboot_delay instead
+# leapp_post_reboot_delay: 120
+leapp_post_reboot_delay: "{{ post_reboot_delay | default(120) }}"
+
 leapp_report_location: /var/log/leapp/leapp-report.json
-remediation_playbooks:
-  - leapp_cgroups-v1_enabled
-  - leapp_cifs_detected
-  - leapp_corrupted_grubenv_file
-  - leapp_custom_network_scripts_detected
-  - leapp_deprecated_sshd_directive
-  - leapp_firewalld_allowzonedrifting
-  - leapp_firewalld_unsupported_tftp_client
-  - leapp_legacy_network_configuration
-  - leapp_loaded_removed_kernel_drivers
-  - leapp_missing_efibootmgr
-  - leapp_missing_pkg
-  - leapp_missing_yum_plugins
-  - leapp_move_usr_directory
-  - leapp_multiple_kernels
-  - leapp_newest_kernel_not_in_use
-  - leapp_nfs_detected
-  - leapp_non_persistent_partitions
-  - leapp_non_standard_openssl_config
-  - leapp_old_postgresql_data
-  - leapp_pam_tally2
-  - leapp_partitions_with_noexec
-  - leapp_relative_symlinks
-  - leapp_remote_using_root
-  - leapp_rpms_with_rsa_sha1_detected
-  - leapp_unavailable_kde
-  - leapp_vdo_check_needed
-remediation_todo: []
+
+# remediation_playbooks is deprecated, use leapp_remediation_playbooks instead
+# leapp_remediation_playbooks:
+#   - leapp_cgroups-v1_enabled
+#   - leapp_cifs_detected
+#   - leapp_corrupted_grubenv_file
+#   - leapp_custom_network_scripts_detected
+#   - leapp_deprecated_sshd_directive
+#   - leapp_firewalld_allowzonedrifting
+#   - leapp_firewalld_unsupported_tftp_client
+#   - leapp_legacy_network_configuration
+#   - leapp_loaded_removed_kernel_drivers
+#   - leapp_missing_efibootmgr
+#   - leapp_missing_pkg
+#   - leapp_missing_yum_plugins
+#   - leapp_move_usr_directory
+#   - leapp_multiple_kernels
+#   - leapp_newest_kernel_not_in_use
+#   - leapp_nfs_detected
+#   - leapp_non_persistent_partitions
+#   - leapp_non_standard_openssl_config
+#   - leapp_old_postgresql_data
+#   - leapp_pam_tally2
+#   - leapp_partitions_with_noexec
+#   - leapp_relative_symlinks
+#   - leapp_remote_using_root
+#   - leapp_rpms_with_rsa_sha1_detected
+#   - leapp_unavailable_kde
+#   - leapp_vdo_check_needed
+leapp_remediation_playbooks: "{{ remediation_playbooks | default([
+  'leapp_cgroups-v1_enabled',
+  'leapp_cifs_detected',
+  'leapp_corrupted_grubenv_file',
+  'leapp_custom_network_scripts_detected',
+  'leapp_deprecated_sshd_directive',
+  'leapp_firewalld_allowzonedrifting',
+  'leapp_firewalld_unsupported_tftp_client',
+  'leapp_legacy_network_configuration',
+  'leapp_loaded_removed_kernel_drivers',
+  'leapp_missing_efibootmgr',
+  'leapp_missing_pkg',
+  'leapp_missing_yum_plugins',
+  'leapp_move_usr_directory',
+  'leapp_multiple_kernels',
+  'leapp_newest_kernel_not_in_use',
+  'leapp_nfs_detected',
+  'leapp_non_persistent_partitions',
+  'leapp_non_standard_openssl_config',
+  'leapp_old_postgresql_data',
+  'leapp_pam_tally2',
+  'leapp_partitions_with_noexec',
+  'leapp_relative_symlinks',
+  'leapp_remote_using_root',
+  'leapp_rpms_with_rsa_sha1_detected',
+  'leapp_unavailable_kde',
+  'leapp_vdo_check_needed'
+]) }}"
+
+# remediation_todo is deprecated, use leapp_remediation_todo instead
+# leapp_remediation_todo: []
+leapp_remediation_todo: "{{ remediation_todo | default([]) }}"
 ...

--- a/roles/remediate/handlers/main.yml
+++ b/roles/remediate/handlers/main.yml
@@ -13,8 +13,8 @@
 
 - name: Reboot the system
   ansible.builtin.reboot:
-    reboot_timeout: "{{ reboot_timeout }}"
-    post_reboot_delay: "{{ post_reboot_delay }}"
-  timeout: "{{ reboot_timeout }}"
+    reboot_timeout: "{{ leapp_reboot_timeout }}"
+    post_reboot_delay: "{{ leapp_post_reboot_delay }}"
+  timeout: "{{ leapp_reboot_timeout }}"
 
 ...

--- a/roles/remediate/tasks/leapp_move_usr_directory.yml
+++ b/roles/remediate/tasks/leapp_move_usr_directory.yml
@@ -153,8 +153,8 @@
         - name: leapp_move_usr_directory | Reboot the system
           ansible.builtin.reboot:
             msg: "Rebooting the system to complete the move of /usr"
-            connect_timeout: "{{ reboot_timeout }}"
-            pre_reboot_delay: "{{ pre_reboot_delay }}"
-            post_reboot_delay: "{{ post_reboot_delay }}"
+            connect_timeout: "{{ leapp_reboot_timeout }}"
+            pre_reboot_delay: "{{ leapp_pre_reboot_delay }}"
+            post_reboot_delay: "{{ leapp_post_reboot_delay }}"
 
 ...

--- a/roles/remediate/tasks/leapp_multiple_kernels.yml
+++ b/roles/remediate/tasks/leapp_multiple_kernels.yml
@@ -21,9 +21,9 @@
 
     - name: leapp_multiple_kernels | Update-and-reboot | Reboot when updates applied
       ansible.builtin.reboot:
-        reboot_timeout: "{{ reboot_timeout }}"
-        post_reboot_delay: "{{ post_reboot_delay }}"
-      timeout: "{{ reboot_timeout }}"
+        reboot_timeout: "{{ leapp_reboot_timeout }}"
+        post_reboot_delay: "{{ leapp_post_reboot_delay }}"
+      timeout: "{{ leapp_reboot_timeout }}"
       when: installed_kernels.stdout_lines[0] != current_kernel.stdout
 
     # TODO: This is slow.  Instead, use filters/map to construct the list

--- a/roles/remediate/tasks/leapp_newest_kernel_not_in_use.yml
+++ b/roles/remediate/tasks/leapp_newest_kernel_not_in_use.yml
@@ -30,8 +30,8 @@
 
         - name: leapp_newest_kernel_not_in_use | Update-and-reboot | Reboot when updates applied
           ansible.builtin.reboot:
-            reboot_timeout: "{{ reboot_timeout }}"
-            post_reboot_delay: "{{ post_reboot_delay }}"
-          timeout: "{{ reboot_timeout }}"
+            reboot_timeout: "{{ leapp_reboot_timeout }}"
+            post_reboot_delay: "{{ leapp_post_reboot_delay }}"
+          timeout: "{{ leapp_reboot_timeout }}"
 
 ...

--- a/roles/remediate/tasks/main.yml
+++ b/roles/remediate/tasks/main.yml
@@ -43,7 +43,7 @@
 
     - name: Remediate the system
       ansible.builtin.include_tasks: "{{ remediation_item }}.yml"
-      loop: "{{ remediation_playbooks | intersect(remediation_todo) }}"
+      loop: "{{ leapp_remediation_playbooks | intersect(leapp_remediation_todo) }}"
       loop_control:
         loop_var: remediation_item
 ...

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -11,27 +11,28 @@ Additionally a list of any non-Red Hat RPM packages that were installed on the s
 | leapp_upgrade_type      | "satellite"           | Set to "cdn" for hosts registered with Red Hat CDN, "rhui" for hosts using rhui repos, and "custom" for custom repos. |
 | leapp_upgrade_opts      |                       | Optional string to define command line options to be passed to the `leapp` command when running the upgrade. |
 | leapp_repos_enabled     |                       | Optional list of repos to limit for use in the upgrade process. |
-| selinux_mode            | same as before upgrade | Define this variable to the desired SELinux mode to be set after the OS upgrade, i.e., enforcing, permissive, or disabled. By default, the SELinux mode will be set to what was found during the pre-upgrade analysis. |
-| set_crypto_policies     | true                  | Boolean to define if system-wide cryptographic policies should be set after the OS upgrade |
-| crypto_policy           | "DEFAULT"             | System-wide cryptographic to set, e.g., "FUTURE", "DEFAULT:SHA1", etc. Refer to the crypto-policies (7) man page for more information. |
-| reboot_timeout          | 7200                  | Integer for maximum seconds to wait for reboot to complete. |
-| upgrade_timeout         | 14400                 | Integer for maximum seconds to wait for reboot to complete during upgrade reboot. |
-| post_reboot_delay       | 120                   | Integer to pass to the reboot post_reboot_delay option. |
+| leapp_selinux_mode            | same as before upgrade | Define this variable to the desired SELinux mode to be set after the OS upgrade, i.e., enforcing, permissive, or disabled. By default, the SELinux mode will be set to what was found during the pre-upgrade analysis. |
+| leapp_set_crypto_policies     | true                  | Boolean to define if system-wide cryptographic policies should be set after the OS upgrade |
+| leapp_crypto_policy           | "DEFAULT"             | System-wide cryptographic to set, e.g., "FUTURE", "DEFAULT:SHA1", etc. Refer to the crypto-policies (7) man page for more information. |
+| leapp_reboot_timeout          | 7200                  | Integer for maximum seconds to wait for reboot to complete. |
+| leapp_upgrade_timeout         | 14400                 | Integer for maximum seconds to wait for reboot to complete during upgrade reboot. |
+| leapp_post_reboot_delay       | 120                   | Integer to pass to the reboot post_reboot_delay option. |
 | leapp_resume_retries    | 360                   | Integer for maximum retries to wait for leapp_resume service no longer exists. |
 | leapp_resume_delay      | 10                    | Integer for seconds between each attempt to check leapp_resume service no longer exists. |
-| update_grub_to_grub_2   | false                 | Boolean to control whether grub gets upgraded to grub 2 in post RHEL 6 to 7 upgrade. |
-| os_path                 | $PATH                 | Variable used to override the default $PATH environmental variable on the target node. |
-| async_timeout_maximum   | 7200                  | Variable used to set the asynchronous task timeout value (in seconds) |
-| async_poll_interval     | 60                    | Variable used to set the asynchronous task polling internal value (in seconds) |
-| check_leapp_analysis_results| true              | Allows for running remediation and going straight to upgrade without re-running analysis. |
-| pre_upgrade_update      | true                  | Boolean to decide if an update and reboot on the running pre-upgrade operating system will run. |
-| post_upgrade_update     | true                   | Boolean to decide if after the upgrade is performed a dnf update will run. |
-| post_upgrade_unset_release| true                | Boolean used to control whether Leapp's RHSM release lock is unset. |
-| post_upgrade_release    |                       | Optional string used to set a specific RHSM release lock after the Leapp upgrade, but before the final update pass. |
-| kernel_modules_to_unload_before_upgrade | []    | A list of kernel modules to be unloaded prior to running leapp. |
-| post_7_to_8_python_interpreter | /usr/libexec/platform-python | For RHEL 7 to 8 upgrades, /usr/bin/python is discovered but not available post upgrade. For 7 to 8 upgrades, ansible_python_interpreter is set to this value post upgrade reboot prior to reconnecting. |
-| infra_leapp_upgrade_system_roles_collection | fedora.linux_system_roles | Can be one of:<br>- 'fedora.linux_system_roles'<br>- 'redhat.rhel_system_roles' |
-| remove_old_rhel_packages | true                 | Boolean to control whether the previous version RHEL packages should be removed. Change to false to maintain behavior of infra.leapp prior to  release 1.6.0. |
+| leapp_update_grub_to_grub_2   | false                 | Boolean to control whether grub gets upgraded to grub 2 in post RHEL 6 to 7 upgrade. |
+| leapp_os_path                 | $PATH                 | Variable used to override the default $PATH environmental variable on the target node. |
+| leapp_async_timeout_maximum   | 7200                  | Variable used to set the asynchronous task timeout value (in seconds) |
+| leapp_async_poll_interval     | 60                    | Variable used to set the asynchronous task polling internal value (in seconds) |
+| leapp_check_analysis_results| true              | Allows for running remediation and going straight to upgrade without re-running analysis. |
+| leapp_pre_upgrade_update      | true                  | Boolean to decide if an update and reboot on the running pre-upgrade operating system will run. |
+| leapp_post_upgrade_update     | true                   | Boolean to decide if after the upgrade is performed a dnf update will run. |
+| leapp_post_upgrade_unset_release| true                | Boolean used to control whether Leapp's RHSM release lock is unset. |
+| leapp_post_upgrade_release    |                       | Optional string used to set a specific RHSM release lock after the Leapp upgrade, but before the final update pass. |
+| leapp_kernel_modules_to_unload_before_upgrade | []    | A list of kernel modules to be unloaded prior to running leapp. |
+| leapp_post_7_to_8_python_interpreter | /usr/libexec/platform-python | For RHEL 7 to 8 upgrades, /usr/bin/python is discovered but not available post upgrade. For 7 to 8 upgrades, ansible_python_interpreter is set to this value post upgrade reboot prior to reconnecting. |
+| leapp_infra_upgrade_system_roles_collection | fedora.linux_system_roles | Can be one of:<br>- 'fedora.linux_system_roles'<br>- 'redhat.rhel_system_roles' |
+| leapp_remove_old_rhel_packages | true                 | Boolean to control whether the previous version RHEL packages should be removed. Change to false to maintain behavior of infra.leapp prior to  release 1.6.0. |
+| leapp_grub_boot_device | null | Optional device path (e.g., /dev/sda) for grub2-install. If not defined, will be auto-detected from /boot or / mount point. |
 
 ## Satellite variables
 
@@ -39,9 +40,9 @@ Activation keys provide a method to identify content views available from Red Ha
 
 | Name                  | Type | Default value           | Description                                     |
 |-----------------------|------|-------------------------|-------------------------------------------------|
-| satellite_organization  | String   |  | Organization used in Satellite definition |
-| satellite_activation_key_leapp     | String |  | Activation key for the content view including both the current RHEL version and the next version |
-| satellite_activation_key_post_leapp     | String |  | Activation key for the content view for the next version post leapp |
+| leapp_satellite_organization  | String   | null | Organization used in Satellite definition |
+| leapp_satellite_activation_key_leapp     | String | null | Activation key for the content view including both the current RHEL version and the next version |
+| leapp_satellite_activation_key_post_leapp     | String | null | Activation key for the content view for the next version post leapp |
 | leapp_repos_enabled    | List | [] | Satellite repo for the satellite client RPM install |
 
 ## Custom repos variables
@@ -50,10 +51,10 @@ See comments in defaults/main.yml for additional details.
 
 | Name                  | Type | Default value           | Description                                     |
 |-----------------------|------|-------------------------|-------------------------------------------------|
-| local_repos_pre_leapp  | List of dicts   | [] | Used to configure repos for yum update before running leapp upgrade (current version).|
-| local_repos_leapp  | List of dicts   | [] | Used to configure next version repos in /etc/leapp/files/leapp_upgrade_repositories.repo.
-| local_repos_post_upgrade  | List of dicts   | [] | Used to configure next version repos post upgrade (can be set to local_repos_leapp if the same)
-| repo_files_to_remove_at_upgrade  | List   | [] | Simpler way to remove /etc/yum.repos.d files before leapp upgrade is run.
+| leapp_local_repos_pre  | List of dicts   | [] | Used to configure repos for yum update before running leapp upgrade (current version).|
+| leapp_local_repos  | List of dicts   | [] | Used to configure next version repos in /etc/leapp/files/leapp_upgrade_repositories.repo.
+| leapp_local_repos_post_upgrade  | List of dicts   | [] | Used to configure next version repos post upgrade (can be set to leapp_local_repos if the same)
+| leapp_repo_files_to_remove_at_upgrade  | List   | [] | Simpler way to remove /etc/yum.repos.d files before leapp upgrade is run.
 | leapp_env_vars | Dict | {} | Environment variables to use when running `leapp` command. See defaults/main.yml for example. |
 
 ## Example playbook

--- a/roles/upgrade/defaults/main.yml
+++ b/roles/upgrade/defaults/main.yml
@@ -1,20 +1,32 @@
 ---
 # defaults file for upgrade
-upgrade_packages_el7:
-  - leapp-upgrade
+# upgrade_packages_el7 is deprecated, use leapp_upgrade_packages_el7 instead
+# leapp_upgrade_packages_el7:
+#   - leapp-upgrade
+leapp_upgrade_packages_el7: "{{ upgrade_packages_el7 | default(['leapp-upgrade']) }}"
 
-upgrade_packages_el8:
-  - leapp-upgrade
+# upgrade_packages_el8 is deprecated, use leapp_upgrade_packages_el8 instead
+# leapp_upgrade_packages_el8:
+#   - leapp-upgrade
+leapp_upgrade_packages_el8: "{{ upgrade_packages_el8 | default(['leapp-upgrade']) }}"
 
-upgrade_packages_el9:
-  - leapp-upgrade
+# upgrade_packages_el9 is deprecated, use leapp_upgrade_packages_el9 instead
+# leapp_upgrade_packages_el9:
+#   - leapp-upgrade
+leapp_upgrade_packages_el9: "{{ upgrade_packages_el9 | default(['leapp-upgrade']) }}"
 
-upgrade_repos_el7:
-  - rhel-7-server-extras-rpms
+# upgrade_repos_el7 is deprecated, use leapp_upgrade_repos_el7 instead
+# leapp_upgrade_repos_el7:
+#   - rhel-7-server-extras-rpms
+leapp_upgrade_repos_el7: "{{ upgrade_repos_el7 | default(['rhel-7-server-extras-rpms']) }}"
 
-upgrade_repos_el8: []
+# upgrade_repos_el8 is deprecated, use leapp_upgrade_repos_el8 instead
+# leapp_upgrade_repos_el8: []
+leapp_upgrade_repos_el8: "{{ upgrade_repos_el8 | default([]) }}"
 
-upgrade_repos_el9: []
+# upgrade_repos_el9 is deprecated, use leapp_upgrade_repos_el9 instead
+# leapp_upgrade_repos_el9: []
+leapp_upgrade_repos_el9: "{{ upgrade_repos_el9 | default([]) }}"
 
 leapp_upgrade_type: satellite
 # leapp_upgrade_type: cdn
@@ -27,92 +39,102 @@ leapp_repos_enabled: []
 # leapp_repos_enabled:
 #   - satellite-client-6-for-rhel-{{ ansible_distribution_major_version | int + 1 }}-x86_64-rpms
 
-rhel_7_network_install_repo_url: http://capsule1.example.com/pub/ISO/RHEL7.9
+# rhel_7_network_install_repo_url is deprecated, use leapp_rhel_7_network_install_repo_url instead
+# leapp_rhel_7_network_install_repo_url: http://capsule1.example.com/pub/ISO/RHEL7.9
+leapp_rhel_7_network_install_repo_url: "{{ rhel_7_network_install_repo_url | default('http://capsule1.example.com/pub/ISO/RHEL7.9') }}"
 
 # Satellite Organization and Activation Keys are required if using Satellite to change content views
 # unless the content view already in use has all required repositories.
-# satellite_organization: Example
-# satellite_activation_key_leapp: rhel{{ ansible_distribution_major_version }}_leapp
-# satellite_activation_key_post_leapp: rhel{{ ansible_distribution_major_version }}_prod
+leapp_satellite_organization: null
+leapp_satellite_activation_key_leapp: null
+leapp_satellite_activation_key_post_leapp: null
 
 # For leapp_upgrade_type == "custom"
 # Used to configure repos before running leapp analysis / installing leapp packages.
-local_repos_pre_leapp: []
-# local_repos_pre_leapp:
+# local_repos_pre_leapp is deprecated, use leapp_local_repos_pre instead
+# leapp_local_repos_pre: []
+leapp_local_repos_pre: "{{ local_repos_pre_leapp | default([]) }}"
+# leapp_local_repos_pre:
 #   - name: rhel-server-7-rpms
 #     description: Red Hat 7 Server
 #     baseurl: http://repo02.example.com/leapp/7Server/rhel-server-7-rpms
-#     # enabled: 1 # Default 1
-#     # gpgcheck: 0 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
-#     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
-#     # state: present # Defaults to present
+#     enabled: 1 # Default 1
+#     gpgcheck: 0 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
+#     file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
+#     state: present # Defaults to present
 #   - name: rhel-server-7-rpms
 #     description: Red Hat 7 Server
 #     baseurl: http://repo02.example.com/leapp/7Server/rhel-server-7-rpms
-#     # enabled: 1 # Default 1
-#     # gpgcheck: 0 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
-#     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
-#     # state: present # Defaults to present
+#     enabled: 1 # Default 1
+#     gpgcheck: 0 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
+#     file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
+#     state: present # Defaults to present
 
 # For leapp_upgrade_type == "custom"
 # Used to generate /etc/leapp/files/leapp_upgrade_repositories.repo
-local_repos_leapp: []
-# local_repos_leapp:
+# local_repos_leapp is deprecated, use leapp_local_repos instead
+# leapp_local_repos: []
+leapp_local_repos: "{{ local_repos_leapp | default([]) }}"
+# leapp_local_repos:
 #   - name: rhel-8-for-x86_64-baseos-rpms
 #     description: Red Hat 8.10 Base OS
 #     baseurl: http://repo03.example.com/8.10/rhel-8-for-x86_64-baseos-rpms
-#     # enabled: 1 # Default 1
-#     # gpgcheck: 0 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
-#     # Can include file in this data structure to reuse this for local_repos_post_upgrade.
-#     # file: local # Will be ignored for leapp_upgrade_repositories.repo
-#     # state: present # Defaults to present.
+#     enabled: 1 # Default 1
+#     gpgcheck: 0 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
+#     Can include file in this data structure to reuse this for local_repos_post_upgrade.
+#     file: local # Will be ignored for leapp_upgrade_repositories.repo
+#     state: present # Defaults to present.
 #   - name: rhel-8-for-x86_64-appstream-rpms
 #     description: Red Hat 8.10 App Stream
 #     baseurl: http://repo03.example.com/8.10/rhel-8-for-x86_64-baseos-rpms
-#     # enabled: 1 # Default 1
-#     # gpgcheck: 0 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
-#     # Can include file in this data structure to reuse this for local_repos_post_upgrade.
-#     # file: local # Will be ignored for leapp_upgrade_repositories.repo
-#     # state: present # Defaults to present.
+#     enabled: 1 # Default 1
+#     gpgcheck: 0 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
+#     Can include file in this data structure to reuse this for local_repos_post_upgrade.
+#     file: local # Will be ignored for leapp_upgrade_repositories.repo
+#     state: present # Defaults to present.
 
 # For leapp_upgrade_type == "custom"
 # Used to rename previous previous repo files with timestamp at the end for future reference.
 # /etc/yum.repos.d/ prepended to file names in task.
-repo_files_to_remove_at_upgrade: []
-# repo_files_to_remove_at_upgrade:
+# repo_files_to_remove_at_upgrade is deprecated, use leapp_repo_files_to_remove_at_upgrade instead
+# leapp_repo_files_to_remove_at_upgrade: []
+leapp_repo_files_to_remove_at_upgrade: "{{ repo_files_to_remove_at_upgrade | default([]) }}"
+# leapp_repo_files_to_remove_at_upgrade:
 #   - rhel7Server.repo
 
 # For leapp_upgrade_type == "custom"
 # Applied using ansible.builtin.yum_repository post upgrade.
-local_repos_post_upgrade: []
-# local_repos_post_upgrade: "{{ local_repos_leapp }}" # If same.
-# local_repos_post_upgrade:
+# local_repos_post_upgrade is deprecated, use leapp_local_repos_post_upgrade instead
+# leapp_local_repos_post_upgrade: []
+leapp_local_repos_post_upgrade: "{{ local_repos_post_upgrade | default(leapp_local_repos | default([])) }}"
+# leapp_local_repos_post_upgrade: "{{ leapp_local_repos }}" # If same.
+# leapp_local_repos_post_upgrade:
 #   - name: rhel-8-for-x86_64-baseos-rpms
 #     description: Red Hat 8 Base OS
 #     baseurl: http://repo01.example.com/8/rhel-8-for-x86_64-baseos-rpms
-#     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
-#     # enabled: 0 # Default 1
-#     # gpgcheck: 1 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
-#     # state: present # Defaults to present.
+#     file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
+#     enabled: 0 # Default 1
+#     gpgcheck: 1 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
+#     state: present # Defaults to present.
 #   - name: rhel-8-for-x86_64-appstream-rpms
 #     description: Red Hat 8 App Stream
 #     baseurl: http://repo01.example.com/8/rhel-8-for-x86_64-baseos-rpms
-#     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
-#     # enabled: 0 # Default 1
-#     # gpgcheck: 1 # Default 0
-#     # gpgkey: XXX # Default omit.
-#     # repo_gpgcheck: 0 # Default omit.
-#     # state: present # Defaults to present.
+#     file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
+#     enabled: 0 # Default 1
+#     gpgcheck: 1 # Default 0
+#     gpgkey: XXX # Default omit.
+#     repo_gpgcheck: 0 # Default omit.
+#     state: present # Defaults to present.
 
 # Dict of env vars to be used when the leapp command is run
 leapp_env_vars: {}
@@ -126,54 +148,99 @@ leapp_env_vars: {}
 # selinux_mode: disabled
 # Default selinux_mode to what was found during the pre-upgrade analysis automation.
 # The config_mode fact is not created if selinux is disabled so default the variable to "disabled"
-selinux_mode: "{{ ansible_facts.ansible_local.pre_ripu.selinux.config_mode | default('disabled') }}"
+# selinux_mode is deprecated, use leapp_selinux_mode instead
+# leapp_selinux_mode: "{{ ansible_facts.ansible_local.pre_ripu.selinux.config_mode | default('disabled') }}"
+leapp_selinux_mode: "{{ selinux_mode | default(ansible_facts.ansible_local.pre_ripu.selinux.config_mode | default('disabled')) }}"
 
 # System-wide cryptographic policies
-# set_crypto_policies: false
-set_crypto_policies: true
-crypto_policy: DEFAULT
-# crypto_policy: FUTURE
-# crypto_policy: DEFAULT:SHA1
+# set_crypto_policies is deprecated, use leapp_set_crypto_policies instead
+# leapp_set_crypto_policies: true
+leapp_set_crypto_policies: "{{ set_crypto_policies | default(true) }}"
+
+# crypto_policy is deprecated, use leapp_crypto_policy instead
+# leapp_crypto_policy: DEFAULT
+leapp_crypto_policy: "{{ crypto_policy | default('DEFAULT') }}"
+# leapp_crypto_policy: FUTURE
+# leapp_crypto_policy: DEFAULT:SHA1
 
 # Whether or not to update from legacy grub to grub2 in post-upgrade steps from RHEL 6 -> 7.
-update_grub_to_grub_2: false
-pre_upgrade_update: true
-post_upgrade_update: true
-post_upgrade_unset_release: true
-post_upgrade_release: ""
+# update_grub_to_grub_2 is deprecated, use leapp_update_grub_to_grub_2 instead
+# leapp_update_grub_to_grub_2: false
+leapp_update_grub_to_grub_2: "{{ update_grub_to_grub_2 | default(false) }}"
+
+# pre_upgrade_update is deprecated, use leapp_pre_upgrade_update instead
+# leapp_pre_upgrade_update: true
+leapp_pre_upgrade_update: "{{ pre_upgrade_update | default(true) }}"
+
+# post_upgrade_update is deprecated, use leapp_post_upgrade_update instead
+# leapp_post_upgrade_update: true
+leapp_post_upgrade_update: "{{ post_upgrade_update | default(true) }}"
+
+# post_upgrade_unset_release is deprecated, use leapp_post_upgrade_unset_release instead
+# leapp_post_upgrade_unset_release: true
+leapp_post_upgrade_unset_release: "{{ post_upgrade_unset_release | default(true) }}"
+
+# post_upgrade_release is deprecated, use leapp_post_upgrade_release instead
+# leapp_post_upgrade_release: ""
+leapp_post_upgrade_release: "{{ post_upgrade_release | default('') }}"
 
 # Used by grub to grub2 upgrade in RHEL 6 to 7 post upgrade, and RHEL 7 to 8 post upgrade.
-# For grub to grub2 upgrade, if grub_boot_device is not defined, the parent device of /boot
+# For grub to grub2 upgrade, if leapp_grub_boot_device is not defined, the parent device of /boot
 # will be used if present, else the parent device of / will be used.
 # For RHEL 7 to 8 post upgrade, used to grub2-install on a device other than the disk
 # /boot is on.
-# grub_boot_device: /dev/sda
+leapp_grub_boot_device: null
 
-reboot_timeout: 7200
-upgrade_timeout: 14400
-post_reboot_delay: 120
+# reboot_timeout is deprecated, use leapp_reboot_timeout instead
+# leapp_reboot_timeout: 7200
+leapp_reboot_timeout: "{{ reboot_timeout | default(7200) }}"
+
+# upgrade_timeout is deprecated, use leapp_upgrade_timeout instead
+# leapp_upgrade_timeout: 14400
+leapp_upgrade_timeout: "{{ upgrade_timeout | default(14400) }}"
+
+# post_reboot_delay is deprecated, use leapp_post_reboot_delay instead
+# leapp_post_reboot_delay: 120
+leapp_post_reboot_delay: "{{ post_reboot_delay | default(120) }}"
 
 leapp_resume_retries: 360
 leapp_resume_delay: 10
 
-os_path: $PATH
+# os_path is deprecated, use leapp_os_path instead
+# leapp_os_path: $PATH
+leapp_os_path: "{{ os_path | default('$PATH') }}"
 
-async_timeout_maximum: 7200
-async_poll_interval: 60
+# async_timeout_maximum is deprecated, use leapp_async_timeout_maximum instead
+# leapp_async_timeout_maximum: 7200
+leapp_async_timeout_maximum: "{{ async_timeout_maximum | default(7200) }}"
 
-check_leapp_analysis_results: true
+# async_poll_interval is deprecated, use leapp_async_poll_interval instead
+# leapp_async_poll_interval: 60
+leapp_async_poll_interval: "{{ async_poll_interval | default(60) }}"
 
-kernel_modules_to_unload_before_upgrade: []
+# check_leapp_analysis_results is deprecated, use leapp_check_analysis_results instead
+# leapp_check_analysis_results: true
+leapp_check_analysis_results: "{{ check_leapp_analysis_results | default(true) }}"
 
-post_7_to_8_python_interpreter: /usr/libexec/platform-python
+# kernel_modules_to_unload_before_upgrade is deprecated, use leapp_kernel_modules_to_unload_before_upgrade instead
+# leapp_kernel_modules_to_unload_before_upgrade: []
+leapp_kernel_modules_to_unload_before_upgrade: "{{ kernel_modules_to_unload_before_upgrade | default([]) }}"
+
+# post_7_to_8_python_interpreter is deprecated, use leapp_post_7_to_8_python_interpreter instead
+# leapp_post_7_to_8_python_interpreter: /usr/libexec/platform-python
+leapp_post_7_to_8_python_interpreter: "{{ post_7_to_8_python_interpreter | default('/usr/libexec/platform-python') }}"
 
 # Set which Ansible Collection to use for the Linux System Roles.
 # For community/upstream, use 'fedora.linux_system_roles'
 # For the RHEL System Roles, use 'redhat.rhel_system_roles'
 # - fedora.linux_system_roles
 # - redhat.rhel_system_roles
-infra_leapp_upgrade_system_roles_collection: fedora.linux_system_roles
+# infra_leapp_upgrade_system_roles_collection is deprecated, use leapp_infra_upgrade_system_roles_collection instead
+# leapp_infra_upgrade_system_roles_collection: fedora.linux_system_roles
+leapp_infra_upgrade_system_roles_collection: "{{ infra_leapp_upgrade_system_roles_collection | default('fedora.linux_system_roles') }}"
 
-remove_old_rhel_packages: true
+# remove_old_rhel_packages is deprecated, use leapp_remove_old_rhel_packages instead
+# leapp_remove_old_rhel_packages: true
+leapp_remove_old_rhel_packages: "{{ remove_old_rhel_packages | default(true) }}"
 
 ...

--- a/roles/upgrade/tasks/grub2-upgrade.yml
+++ b/roles/upgrade/tasks/grub2-upgrade.yml
@@ -17,9 +17,9 @@
     group: root
     mode: "0644"
 
-# If grub_boot_device is not defined, attempt to determine it based on /boot if present, or / if /boot is not present.
-- name: grub2-upgrade | Determine grub_boot_device if not defined
-  when: grub_boot_device is not defined
+# If leapp_grub_boot_device is not defined, attempt to determine it based on /boot if present, or / if /boot is not present.
+- name: grub2-upgrade | Determine leapp_grub_boot_device if not defined
+  when: leapp_grub_boot_device is none
   block:
     - name: grub2-upgrade | Determine if /boot is a mount point
       ansible.builtin.set_fact:
@@ -37,17 +37,17 @@
 
     - name: grub2-upgrade | Get boot device from boot device dict
       ansible.builtin.set_fact:
-        grub_boot_device: "{{ boot_device_dict.device | regex_replace('[1-9]$', '') }}"
+        leapp_grub_boot_device: "{{ boot_device_dict.device | regex_replace('[1-9]$', '') }}"
 
 - name: grub2-upgrade | Run grub2-install
   ansible.builtin.shell: |
-    export PATH={{ os_path }}
-    grub2-install {{ grub_boot_device }}
+    export PATH={{ leapp_os_path }}
+    grub2-install {{ leapp_grub_boot_device }}
   changed_when: true
 
 - name: grub2-upgrade | Run grub2-mkconfig
   ansible.builtin.shell: |
-    export PATH={{ os_path }}
+    export PATH={{ leapp_os_path }}
     set -o pipefail
     grub2-mkconfig -o /boot/grub2/grub.cfg
     grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
@@ -60,8 +60,8 @@
 
 - name: grub2-upgrade | Reboot to start using grub2
   ansible.builtin.reboot:
-    reboot_timeout: "{{ reboot_timeout }}"
-    post_reboot_delay: "{{ post_reboot_delay }}"
-  timeout: "{{ reboot_timeout }}"
+    reboot_timeout: "{{ leapp_reboot_timeout }}"
+    post_reboot_delay: "{{ leapp_post_reboot_delay }}"
+  timeout: "{{ leapp_reboot_timeout }}"
 
 ...

--- a/roles/upgrade/tasks/handle-old-packages.yml
+++ b/roles/upgrade/tasks/handle-old-packages.yml
@@ -4,7 +4,7 @@
   ansible.builtin.shell:
     cmd: >-
       set -o pipefail;
-      export PATH={{ os_path }};
+      export PATH={{ leapp_os_path }};
       rpm -qa |
       grep -ve '[\.|+]el{{ ansible_distribution_major_version }}' |
       grep -vE '^(gpg-pubkey|libmodulemd|katello-ca-consumer)' |
@@ -60,7 +60,7 @@
     name: "{{ unsigned_packages_post }}"
     state: absent
   when:
-    - remove_old_rhel_packages
+    - leapp_remove_old_rhel_packages
     - ansible_distribution_major_version | int >= 7
 
 ...

--- a/roles/upgrade/tasks/leapp-post-upgrade-crypto.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade-crypto.yml
@@ -1,7 +1,7 @@
 ---
 - name: leapp-post-upgrade-crypto | Include rhel_system_roles.crypto_policies role
   ansible.builtin.include_role:
-    name: "{{ infra_leapp_upgrade_system_roles_collection }}.crypto_policies"
+    name: "{{ leapp_infra_upgrade_system_roles_collection }}.crypto_policies"
   vars:
-    crypto_policies_policy: "{{ crypto_policy }}"
+    crypto_policies_policy: "{{ leapp_crypto_policy }}"
 ...

--- a/roles/upgrade/tasks/leapp-post-upgrade-selinux.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade-selinux.yml
@@ -2,29 +2,29 @@
 # TODO: Relocate to validation and compare to previous selinux state.
 # - name: leapp-post-upgrade-selinux | Ensure there are no SELinux denials
 #   ansible.builtin.shell: >
-#     export PATH={{ os_path }};
+#     export PATH={{ leapp_os_path }};
 #     ausearch -m AVC,USER_AVC -ts boot 2>&1
 #   register: ausearch_results
 #   changed_when: false
 #   failed_when: ausearch_results.stdout != "<no matches>"
 
-- name: leapp-post-upgrade-selinux | SELinux mode is set to {{ selinux_mode }}
+- name: leapp-post-upgrade-selinux | SELinux mode is set to {{ leapp_selinux_mode }}
   ansible.posix.selinux:
     policy: targeted
-    state: "{{ selinux_mode }}"
+    state: "{{ leapp_selinux_mode }}"
   register: selinux_results
 
 - name: leapp-post-upgrade-selinux | Reboot when required for SELinux change
   ansible.builtin.reboot:
-    reboot_timeout: "{{ reboot_timeout }}"
-    post_reboot_delay: "{{ post_reboot_delay }}"
-  timeout: "{{ reboot_timeout }}"
+    reboot_timeout: "{{ leapp_reboot_timeout }}"
+    post_reboot_delay: "{{ leapp_post_reboot_delay }}"
+  timeout: "{{ leapp_reboot_timeout }}"
   when: selinux_results.reboot_required
 
-- name: leapp-post-upgrade-selinux | Verify SELinux is set to {{ selinux_mode }}
+- name: leapp-post-upgrade-selinux | Verify SELinux is set to {{ leapp_selinux_mode }}
   ansible.posix.selinux:
     policy: targeted
-    state: "{{ selinux_mode }}"
+    state: "{{ leapp_selinux_mode }}"
   check_mode: true
   register: selinux_check_results
   failed_when: selinux_check_results.changed

--- a/roles/upgrade/tasks/leapp-post-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade.yml
@@ -2,7 +2,7 @@
 # /etc/dnf/dnf.conf is an ini file and could be parsed to check if exclude has value and run this conditionally.
 - name: leapp-post-upgrade | Clean dnf exclude list
   ansible.builtin.shell: >
-    export PATH={{ os_path }};
+    export PATH={{ leapp_os_path }};
     dnf config-manager --save --setopt exclude=''
   changed_when: true
 
@@ -20,7 +20,7 @@
 
     - name: leapp-post-upgrade | Remove weak modules from old kernels
       ansible.builtin.shell: |
-        export PATH={{ os_path }}
+        export PATH={{ leapp_os_path }}
         set -o pipefail
         [ -x /usr/sbin/weak-modules ] && /usr/sbin/weak-modules --remove-kernel {{ item.path | basename }}
       loop: "{{ old_kernels.files }}"
@@ -29,7 +29,7 @@
 
     - name: leapp-post-upgrade | Remove the old kernels from the boot loader entry
       ansible.builtin.shell: |
-        export PATH={{ os_path }}
+        export PATH={{ leapp_os_path }}
         set -o pipefail
         /bin/kernel-install remove {{ item.path | basename }} {{ item.path }}/vmlinuz
       loop: "{{ old_kernels.files }}"
@@ -47,13 +47,13 @@
     {{ ansible_facts.ansible_local.pre_ripu.distribution_major_version }}
   ansible.builtin.shell: >-
     set -o pipefail;
-    export PATH={{ os_path }};
+    export PATH={{ leapp_os_path }};
     grubby --info=ALL | grep -E "^title=.* {{
     ansible_facts.ansible_local.pre_ripu.distribution_major_version
     }}\.[0-9]+ " -B 4 | grep "^kernel"
     | sed -n 's/.*kernel="\([^"]*\)".*/\1/p' || echo ""
   register: leapp_upgrade_outdated_kernels
-  when: remove_old_rhel_packages
+  when: leapp_remove_old_rhel_packages
   changed_when: false
 
 - name: leapp-post-upgrade | Debug kernel paths for outdated RHEL
@@ -64,7 +64,7 @@
   ansible.builtin.command: grubby --remove-kernel={{ item | quote }}
   loop: "{{ leapp_upgrade_outdated_kernels.stdout_lines }}"
   when:
-    - remove_old_rhel_packages
+    - leapp_remove_old_rhel_packages
     - leapp_upgrade_outdated_kernels.stdout | length > 0
   changed_when: true
 
@@ -89,21 +89,21 @@
 
 - name: leapp-post-upgrade | Unset subscription-manager release
   ansible.builtin.shell: >
-    export PATH={{ os_path }};
+    export PATH={{ leapp_os_path }};
     subscription-manager release --unset
   when:
     - leapp_upgrade_type == 'satellite' or leapp_upgrade_type == 'cdn'
-    - post_upgrade_unset_release | bool
-    - post_upgrade_release | length == 0
+    - leapp_post_upgrade_unset_release | bool
+    - leapp_post_upgrade_release | length == 0
   changed_when: true
 
 - name: leapp-post-upgrade | Set subscription-manager release
   ansible.builtin.shell: >
-    export PATH={{ os_path }};
-    subscription-manager release --set {{ post_upgrade_release }}
+    export PATH={{ leapp_os_path }};
+    subscription-manager release --set {{ leapp_post_upgrade_release }}
   when:
     - leapp_upgrade_type == 'satellite' or leapp_upgrade_type == 'cdn'
-    - post_upgrade_release | length > 0
+    - leapp_post_upgrade_release | length > 0
   changed_when: true
 
 - name: leapp-post-upgrade | Unset release via yum variable for RHUI upgrades
@@ -112,34 +112,34 @@
     state: absent
   when:
     - leapp_upgrade_type == 'rhui'
-    - post_upgrade_unset_release | bool
-    - post_upgrade_release | length == 0
+    - leapp_post_upgrade_unset_release | bool
+    - leapp_post_upgrade_release | length == 0
 
 - name: leapp-post-upgrade | Set release via yum variable for RHUI upgrades
   ansible.builtin.copy:
-    content: "{{ post_upgrade_release }}\n"
+    content: "{{ leapp_post_upgrade_release }}\n"
     dest: /etc/yum/vars/releasever
     owner: root
     group: root
     mode: '0644'
   when:
     - leapp_upgrade_type == 'rhui'
-    - post_upgrade_release | length > 0
+    - leapp_post_upgrade_release | length > 0
 
 - name: leapp-post-upgrade | "Register to post leapp activation key"
   community.general.redhat_subscription:
     state: present
-    activationkey: "{{ satellite_activation_key_post_leapp }}"
-    org_id: "{{ satellite_organization }}"
+    activationkey: "{{ leapp_satellite_activation_key_post_leapp }}"
+    org_id: "{{ leapp_satellite_organization }}"
     force_register: true
   when:
     - leapp_upgrade_type == 'satellite'
-    - satellite_organization is defined
-    - satellite_activation_key_post_leapp is defined
+    - leapp_satellite_organization is not none
+    - leapp_satellite_activation_key_post_leapp is not none
 
 - name: leapp-post-upgrade | Include custom_local_repos for local_repos_post_upgrade
   vars:
-    __repos: "{{ local_repos_post_upgrade }}"
+    __repos: "{{ leapp_local_repos_post_upgrade }}"
   ansible.builtin.include_role:
     name: infra.leapp.common
     tasks_from: custom_local_repos
@@ -162,7 +162,7 @@
 
 - name: leapp-post-upgrade | Reinstall the rescue kernel files when old ones were found
   ansible.builtin.shell: >
-    export PATH={{ os_path }};
+    export PATH={{ leapp_os_path }};
     /usr/lib/kernel/install.d/51-dracut-rescue.install add "$(uname -r)" /boot "/boot/vmlinuz-$(uname -r)"
   when: __rescue_kernel_files.files | length > 0
   changed_when: true
@@ -170,8 +170,8 @@
 - name: leapp-post-upgrade | Include update-and-reboot.yml
   ansible.builtin.include_tasks: update-and-reboot.yml
   when:
-    - post_upgrade_update | bool
-    - leapp_upgrade_type != "custom" or local_repos_post_upgrade | length > 0
+    - leapp_post_upgrade_update | bool
+    - leapp_upgrade_type != "custom" or leapp_local_repos_post_upgrade | length > 0
 
 # TODO: Validate RHEL OS versions again?
 
@@ -180,5 +180,5 @@
 
 - name: leapp-post-upgrade | Include tasks for leapp post upgrade crypto policies
   ansible.builtin.include_tasks: leapp-post-upgrade-crypto.yml
-  when: set_crypto_policies | bool
+  when: leapp_set_crypto_policies | bool
 ...

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -3,28 +3,28 @@
   ansible.builtin.include_role:
     name: infra.leapp.common
     tasks_from: parse_leapp_report.yml
-  when: check_leapp_analysis_results
+  when: leapp_check_analysis_results
 
 - name: leapp-upgrade | Verify no inhibitor results found during preupgrade
   ansible.builtin.assert:
     that: not upgrade_inhibited
     msg: Inhibitors found, please investigate and rerun analysis.
-  when: check_leapp_analysis_results
+  when: leapp_check_analysis_results
 
 - name: leapp-upgrade | Register to leapp activation key
   community.general.redhat_subscription:
     state: present
-    activationkey: "{{ satellite_activation_key_leapp }}"
-    org_id: "{{ satellite_organization }}"
+    activationkey: "{{ leapp_satellite_activation_key_leapp }}"
+    org_id: "{{ leapp_satellite_organization }}"
     force_register: true
   when:
     - leapp_upgrade_type == 'satellite'
-    - satellite_organization is defined
-    - satellite_activation_key_leapp is defined
+    - leapp_satellite_organization is not none
+    - leapp_satellite_activation_key_leapp is not none
 
 - name: leapp-upgrade | Include custom_local_repos for local_repos_pre_leapp
   vars:
-    __repos: "{{ local_repos_pre_leapp }}"
+    __repos: "{{ leapp_local_repos_pre }}"
   ansible.builtin.include_role:
     name: infra.leapp.common
     tasks_from: custom_local_repos
@@ -32,66 +32,66 @@
 
 - name: leapp-upgrade | Install packages for upgrade from RHEL 7
   ansible.builtin.package:
-    name: "{{ upgrade_packages_el7 }}"
-    enablerepo: "{{ upgrade_repos_el7 }}"
+    name: "{{ leapp_upgrade_packages_el7 }}"
+    enablerepo: "{{ leapp_upgrade_repos_el7 }}"
     state: latest # noqa package-latest
   when: ansible_distribution_major_version|int == 7
 
 - name: leapp-upgrade | Install packages for upgrade from RHEL 8
   ansible.builtin.package:
-    name: "{{ upgrade_packages_el8 }}"
-    enablerepo: "{{ upgrade_repos_el8 }}"
+    name: "{{ leapp_upgrade_packages_el8 }}"
+    enablerepo: "{{ leapp_upgrade_repos_el8 }}"
     state: latest # noqa package-latest
   when: ansible_distribution_major_version|int == 8
 
 - name: leapp-upgrade | Install packages for upgrade from RHEL 9
   ansible.builtin.package:
-    name: "{{ upgrade_packages_el9 }}"
-    enablerepo: "{{ upgrade_repos_el9 }}"
+    name: "{{ leapp_upgrade_packages_el9 }}"
+    enablerepo: "{{ leapp_upgrade_repos_el9 }}"
     state: latest # noqa package-latest
   when: ansible_distribution_major_version|int == 9
 
 - name: leapp-upgrade | Include update-and-reboot.yml
   ansible.builtin.include_tasks: update-and-reboot.yml
-  when: pre_upgrade_update | bool
+  when: leapp_pre_upgrade_update | bool
 
 - name: leapp-upgrade | Create /etc/leapp/files/leapp_upgrade_repositories.repo
   vars:
-    __repos: "{{ local_repos_leapp }}"
+    __repos: "{{ leapp_local_repos }}"
     __leapp_repo_file: /etc/leapp/files/leapp_upgrade_repositories
   ansible.builtin.include_role:
     name: infra.leapp.common
     tasks_from: custom_local_repos
   when:
     - leapp_upgrade_type == 'custom'
-    - local_repos_leapp | length > 0
+    - leapp_local_repos | length > 0
 
 - name: leapp-upgrade | Include disable-previous-repo-files.yml
   ansible.builtin.include_tasks: disable-previous-repo-files.yml
   loop:
-    "{{ repo_files_to_remove_at_upgrade }}"
+    "{{ leapp_repo_files_to_remove_at_upgrade }}"
   when: leapp_upgrade_type == "custom"
 
 - name: leapp-upgrade | Include rmmod-kernel-modules.yml
   ansible.builtin.include_tasks: rmmod-kernel-modules.yml
-  loop: "{{ kernel_modules_to_unload_before_upgrade }}"
+  loop: "{{ leapp_kernel_modules_to_unload_before_upgrade }}"
 
 - name: leapp-upgrade | Block to rescue leapp failures to collect errors
   block:
     - name: leapp-upgrade | Start Leapp OS upgrade
       ansible.builtin.shell: >
         set -o pipefail;
-        export PATH={{ os_path }};
+        export PATH={{ leapp_os_path }};
         ulimit -n 16384;
         leapp upgrade --report-schema=1.2.0
         {{ leapp_upgrade_opts }}
-        {{ leapp_enable_repos_args }}
-        2>&1 | tee -a {{ log_file }}
+        {{ __leapp_enable_repos_args }}
+        2>&1 | tee -a {{ leapp_log_file }}
       environment: "{{ leapp_env_vars }}"
       args:
         executable: /bin/bash
-      async: "{{ async_timeout_maximum | int }}"
-      poll: "{{ async_poll_interval | int }}"
+      async: "{{ leapp_async_timeout_maximum | int }}"
+      poll: "{{ leapp_async_poll_interval | int }}"
       changed_when: true
   rescue:
     - name: leapp-upgrade | Run parse_leapp_report to check for inhibitors
@@ -113,19 +113,19 @@
       ansible.builtin.fail:
         msg: >-
           Errors encountered running Leapp upgrade command.
-          Review the tasks above or the result file at {{ result_filename }}.
+          Review the tasks above or the result file at {{ leapp_result_filename }}.
 
 - name: leapp-upgrade | Reboot to continue Leapp OS upgrade
   ansible.builtin.reboot:
     msg: Host is starting Leapp OS upgrade now!
-    reboot_timeout: "{{ upgrade_timeout }}"
-    post_reboot_delay: "{{ post_reboot_delay }}"
-  timeout: "{{ upgrade_timeout }}"
+    reboot_timeout: "{{ leapp_upgrade_timeout }}"
+    post_reboot_delay: "{{ leapp_post_reboot_delay }}"
+  timeout: "{{ leapp_upgrade_timeout }}"
 
 # Ansible discovers /usr/bin/python on RHEL 7, then on RHEL 8 it is no longer available.
 - name: leapp-upgrade | Set python interpreter to /usr/libexec/platform-python since /usr/bin/python is no longer available
   ansible.builtin.set_fact:
-    ansible_python_interpreter: "{{ post_7_to_8_python_interpreter }}"
+    ansible_python_interpreter: "{{ leapp_post_7_to_8_python_interpreter }}"
   when: ansible_distribution_major_version == "7"
 
 - name: leapp-upgrade | Wait for leapp_resume run once service to no longer exist
@@ -140,18 +140,18 @@
   delay: "{{ leapp_resume_delay }}"
 
 - name: leapp-upgrade | Block to handle grub_boot_device option
-  when: grub_boot_device is defined
+  when: leapp_grub_boot_device is not none
   block:
     - name: leapp-upgrade | Run grub2-install
       ansible.builtin.shell: >
-        export PATH={{ os_path }};
-        grub2-install {{ grub_boot_device }}
+        export PATH={{ leapp_os_path }};
+        grub2-install {{ leapp_grub_boot_device }}
       changed_when: true
 
     - name: leapp-upgrade | Reboot to pickup grub update
       ansible.builtin.reboot:
-        reboot_timeout: "{{ reboot_timeout }}"
-        post_reboot_delay: "{{ post_reboot_delay }}"
-      timeout: "{{ reboot_timeout }}"
+        reboot_timeout: "{{ leapp_reboot_timeout }}"
+        post_reboot_delay: "{{ leapp_post_reboot_delay }}"
+      timeout: "{{ leapp_reboot_timeout }}"
 
 ...

--- a/roles/upgrade/tasks/redhat-upgrade-tool-post-upgrade.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-post-upgrade.yml
@@ -7,22 +7,22 @@
 
 - name: redhat-upgrade-tool-post-upgrade | "Register to post upgrade activation key"
   ansible.builtin.shell: >
-    export PATH={{ os_path }};
+    export PATH={{ leapp_os_path }};
     subscription-manager register
-    --org="{{ satellite_organization }}"
-    --activationkey="{{ satellite_activation_key_post_leapp }}"
+    --org="{{ leapp_satellite_organization }}"
+    --activationkey="{{ leapp_satellite_activation_key_post_leapp }}"
     --force
   register: sub_man_reg
   when:
     - leapp_upgrade_type == 'satellite'
-    - satellite_organization is defined
-    - satellite_activation_key_post_leapp is defined
+    - leapp_satellite_organization is not none
+    - leapp_satellite_activation_key_post_leapp is not none
   failed_when: false
   changed_when: true
 
 - name: redhat-upgrade-tool-post-upgrade | Include custom_local_repos for local_repos_post_upgrade
   vars:
-    __repos: "{{ local_repos_post_upgrade }}"
+    __repos: "{{ leapp_local_repos_post_upgrade }}"
   ansible.builtin.include_role:
     name: infra.leapp.common
     tasks_from: custom_local_repos
@@ -35,7 +35,7 @@
   ansible.builtin.include_tasks: grub2-upgrade.yml
   when:
     - ansible_architecture == 'x86_64'
-    - update_grub_to_grub_2
+    - leapp_update_grub_to_grub_2
 
 - name: redhat-upgrade-tool-post-upgrade | Include update-and-reboot.yml
   ansible.builtin.include_tasks: update-and-reboot.yml

--- a/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
@@ -1,39 +1,39 @@
 ---
 - name: redhat-upgrade-tool-upgrade | Run preupg --riskcheck
   ansible.builtin.shell: >
-    export PATH={{ os_path }};
+    export PATH={{ leapp_os_path }};
     preupg --riskcheck
   register: preupg
   changed_when: false
   failed_when: false
-  when: check_leapp_analysis_results
+  when: leapp_check_analysis_results
 
 - name: redhat-upgrade-tool-upgrade | Assert that preupg was successful
   ansible.builtin.assert:
-    that: not preupg_return_codes[preupg.rc].inhibited
-    msg: "{{ preupg_return_codes[preupg.rc].msg }}"
-  when: check_leapp_analysis_results
+    that: not __leapp_preupg_return_codes[preupg.rc].inhibited
+    msg: "{{ __leapp_preupg_return_codes[preupg.rc].msg }}"
+  when: leapp_check_analysis_results
 
 # TODO: Having issues with community.general.redhat_subscription and subscription-manager on RHEL 6.
 - name: redhat-upgrade-tool-upgrade | Register to leapp activation key
   ansible.builtin.shell: >
     set -o pipefail;
-    export PATH={{ os_path }};
+    export PATH={{ leapp_os_path }};
     subscription-manager register
-    --org_id: "{{ satellite_organization }}"
-    activationkey: "{{ satellite_activation_key_leapp }}"
+    --org_id: "{{ leapp_satellite_organization }}"
+    activationkey: "{{ leapp_satellite_activation_key_leapp }}"
     force_register: true
   register: sub_man_reg
   when:
     - leapp_upgrade_type == 'satellite'
-    - satellite_organization is defined
-    - satellite_activation_key_leapp is defined
+    - leapp_satellite_organization is not none
+    - leapp_satellite_activation_key_leapp is not none
   failed_when: false
   changed_when: true
 
 - name: redhat-upgrade-tool-upgrade | Include custom_local_repos for local_repos_post_upgrade
   vars:
-    __repos: "{{ local_repos_pre_leapp }}"
+    __repos: "{{ leapp_local_repos_pre }}"
   ansible.builtin.include_role:
     name: infra.leapp.common
     tasks_from: custom_local_repos
@@ -67,39 +67,39 @@
 
 - name: redhat-upgrade-tool-upgrade | Include disable-previous-repo-files.yml
   ansible.builtin.include_tasks: disable-previous-repo-files.yml
-  loop: "{{ repo_files_to_remove_at_upgrade }}"
+  loop: "{{ leapp_repo_files_to_remove_at_upgrade }}"
   when: leapp_upgrade_type == "custom"
 
 - name: redhat-upgrade-tool-upgrade | Install RPM Key for RHEL 7 ISO Repository
   ansible.builtin.rpm_key:
-    key: "{{ rhel_7_network_install_repo_url }}/RPM-GPG-KEY-redhat-release"
+    key: "{{ leapp_rhel_7_network_install_repo_url }}/RPM-GPG-KEY-redhat-release"
     state: present
   when: leapp_upgrade_type == "custom"
 
 - name: redhat-upgrade-tool-upgrade | Include rmmod-kernel-modules.yml
   ansible.builtin.include_tasks: rmmod-kernel-modules.yml
-  loop: "{{ kernel_modules_to_unload_before_upgrade }}"
+  loop: "{{ leapp_kernel_modules_to_unload_before_upgrade }}"
 
 # --cleanup-post removes Red Hat signed RHEL 6 packages and in theory should be safe.
 - name: redhat-upgrade-tool-upgrade | Run redhat-upgrade-tool
   ansible.builtin.shell: >
     set -o pipefail;
-    export PATH={{ os_path }};
-    redhat-upgrade-tool --network 7.9 --instrepo {{ rhel_7_network_install_repo_url }} --force --cleanup-post
-    2>&1 | tee -a {{ log_file }}
+    export PATH={{ leapp_os_path }};
+    redhat-upgrade-tool --network 7.9 --instrepo {{ leapp_rhel_7_network_install_repo_url }} --force --cleanup-post
+    2>&1 | tee -a {{ leapp_log_file }}
   register: redhat_upgrade_tool
   args:
     executable: /bin/bash
-  async: "{{ async_timeout_maximum | int }}"
-  poll: "{{ async_poll_interval | int }}"
+  async: "{{ leapp_async_timeout_maximum | int }}"
+  poll: "{{ leapp_async_poll_interval | int }}"
   # failed_when: false
   changed_when: true
 
 - name: redhat-upgrade-tool-upgrade | Reboot to continue OS upgrade
   ansible.builtin.reboot:
     msg: Host is starting OS upgrade now!
-    reboot_timeout: "{{ upgrade_timeout }}"
-    post_reboot_delay: "{{ post_reboot_delay }}"
-  timeout: "{{ upgrade_timeout }}"
+    reboot_timeout: "{{ leapp_upgrade_timeout }}"
+    post_reboot_delay: "{{ leapp_post_reboot_delay }}"
+  timeout: "{{ leapp_upgrade_timeout }}"
 
 ...

--- a/roles/upgrade/tasks/update-and-reboot.yml
+++ b/roles/upgrade/tasks/update-and-reboot.yml
@@ -4,14 +4,14 @@
     name: "*"
     state: latest # noqa package-latest
   register: updates_available
-  async: "{{ async_timeout_maximum | int }}"
-  poll: "{{ async_poll_interval | int }}"
+  async: "{{ leapp_async_timeout_maximum | int }}"
+  poll: "{{ leapp_async_poll_interval | int }}"
 
 - name: update-and-reboot | Reboot when updates applied
   ansible.builtin.reboot:
-    reboot_timeout: "{{ reboot_timeout }}"
-    post_reboot_delay: "{{ post_reboot_delay }}"
-  timeout: "{{ reboot_timeout }}"
+    reboot_timeout: "{{ leapp_reboot_timeout }}"
+    post_reboot_delay: "{{ leapp_post_reboot_delay }}"
+  timeout: "{{ leapp_reboot_timeout }}"
   when: updates_available.changed # noqa: no-handler
 
 ...

--- a/roles/upgrade/tests/tests_default.yml
+++ b/roles/upgrade/tests/tests_default.yml
@@ -3,7 +3,7 @@
   hosts: all
   vars:
     job_name: test_upgrade
-    check_leapp_analysis_results: false
+    leapp_check_analysis_results: false
   tasks:
     - name: Test | Run upgrade
       block:

--- a/roles/upgrade/vars/main.yml
+++ b/roles/upgrade/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 # vars file for upgrade
-leapp_enable_repos_args: "{{ ('--enablerepo ' + leapp_repos_enabled | default([], true) | join(' --enablerepo '))
+__leapp_enable_repos_args: "{{ ('--enablerepo ' + leapp_repos_enabled | default([], true) | join(' --enablerepo '))
   if leapp_repos_enabled | length > 0 else '' }}"
 
-result_filename: "{{ '/root/preupgrade/result.txt' if ansible_distribution_major_version == '6'
+leapp_result_filename: "{{ '/root/preupgrade/result.txt' if ansible_distribution_major_version == '6'
   else '/var/log/leapp/leapp-report.txt' }}"
 ...

--- a/tests/tasks/common_upgrade_tasks.yml
+++ b/tests/tasks/common_upgrade_tasks.yml
@@ -35,11 +35,11 @@
 
 - name: common_upgrade_tasks | Initialize remediation_todo
   ansible.builtin.set_fact:
-    remediation_todo: []
+    leapp_remediation_todo: []
 
 - name: common_upgrade_tasks | Map inhibitors to remediation_todo
   ansible.builtin.set_fact:
-    remediation_todo: "{{ remediation_todo + [title_map[map_key]] }}"
+    leapp_remediation_todo: "{{ leapp_remediation_todo | default([]) + [title_map[map_key]] }}"
   loop: "{{ inhibitor_titles }}"
   loop_control:
     loop_var: inhibitor_title
@@ -49,7 +49,7 @@
 
 - name: common_upgrade_tasks | Debug remediation_todo
   ansible.builtin.debug:
-    var: remediation_todo
+    var: leapp_remediation_todo
 
 - name: common_upgrade_tasks | Run remediation
   ansible.builtin.include_role:


### PR DESCRIPTION
1. Prefix variables that are not prefixed already.
2. Edit variables that had leapp in names but not as prefix to use leapp_ as prefix.
3. Assign old variables to new varnames if an old name is set for backward compatibility.
4. Save variables with normal values (without the default filter for backward compatilibility) in a comment so that we can easily remove compatibility in future when needed. Say, in couple years when we are sure that no users have old deprecated variables set.