### PR TITLE
refactor: clean up jinja, vars, common variables, ansible-lint warnings

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -81,12 +81,6 @@ enable_list:
 # Ansible-lint does not fail on warnings from the rules or tags listed below
 warn_list:
   - experimental # experimental is included in the implicit list
-  - git-latest # Allow for newest git version
-  - package-latest # Allow newest package version
-  - risky-file-permissions # File permissions unset or incorrect.
-  - template-instead-of-copy # Templated files should use template instead of copy
-  - sanity[cannot-ignore] # cope with shebang test bug
-  - jinja[spacing] # Jinja spacing warnings that rarely provide helpful information
 
 # Some rules can transform files to fix (or make it easier to fix) identified
 # errors. `ansible-lint --fix` will reformat YAML files and run these transforms.

--- a/changelogs/fragments/refactor-vars-jinja-ansible-lint.yml
+++ b/changelogs/fragments/refactor-vars-jinja-ansible-lint.yml
@@ -1,0 +1,9 @@
+---
+minor_changes:
+  - Fix jinja warnings - use default variables for lists instead of jinja.
+  - Remove leapp-upgrade package before each test to ensure role will install it.
+  - Remove leapp_inhibitors from vars file - it is a set_fact.
+  - Get default remediations by reading files from remediation tasks directory.
+  - Move common variables from analysis and upgrade into common.
+
+...

--- a/roles/analysis/defaults/main.yml
+++ b/roles/analysis/defaults/main.yml
@@ -1,70 +1,44 @@
 ---
 # defaults file for analysis
 # analysis_packages_el6 is deprecated, use leapp_analysis_packages_el6 instead
-# leapp_analysis_packages_el6:
-#   - preupgrade-assistant
-#   - preupgrade-assistant-el6toel7
-#   - redhat-upgrade-tool
-#   - openscap
-#   - openscap-engine-sce
-leapp_analysis_packages_el6: "{{ analysis_packages_el6 | default([
-  'preupgrade-assistant',
-  'preupgrade-assistant-el6toel7',
-  'redhat-upgrade-tool',
-  'openscap',
-  'openscap-engine-sce'
-]) }}"
+default_leapp_analysis_packages_el6:
+  - preupgrade-assistant
+  - preupgrade-assistant-el6toel7
+  - redhat-upgrade-tool
+  - openscap
+  - openscap-engine-sce
+leapp_analysis_packages_el6: "{{ analysis_packages_el6 | default(default_leapp_analysis_packages_el6) }}"
 
 # analysis_packages_el7 is deprecated, use leapp_analysis_packages_el7 instead
-# leapp_analysis_packages_el7:
-#   TODO: Seems to cause package dependency problems with post upgrade cleanup.
-#   - leapp-upgrade-el7toel8
-#   Try this instead.
-#   - leapp-upgrade
-leapp_analysis_packages_el7: "{{ analysis_packages_el7 | default([
-  'leapp-upgrade'
-]) }}"
+default_leapp_analysis_packages_el7:
+  - leapp-upgrade
+leapp_analysis_packages_el7: "{{ analysis_packages_el7 | default(default_leapp_analysis_packages_el7) }}"
+
 # analysis_packages_el8 is deprecated, use leapp_analysis_packages_el8 instead
-# leapp_analysis_packages_el8:
-#   TODO: Seems to cause package dependency problems with post upgrade cleanup.
-#   - leapp-upgrade-el8toel9
-#   Try this instead.
-#   - leapp-upgrade
-#   TODO: This should be part of inhibitor remediation.
-#   - vdo
-#   TODO: only w/ rhui for aws
-#   - leapp-rhui-aws
-leapp_analysis_packages_el8: "{{ analysis_packages_el8 | default([
-  'leapp-upgrade'
-]) }}"
+default_leapp_analysis_packages_el8:
+  - leapp-upgrade
+leapp_analysis_packages_el8: "{{ analysis_packages_el8 | default(default_leapp_analysis_packages_el8) }}"
+
 # analysis_packages_el9 is deprecated, use leapp_analysis_packages_el9 instead
-# leapp_analysis_packages_el9:
-#   - leapp-upgrade
-leapp_analysis_packages_el9: "{{ analysis_packages_el9 | default([
-  'leapp-upgrade'
-]) }}"
+default_leapp_analysis_packages_el9:
+  - leapp-upgrade
+leapp_analysis_packages_el9: "{{ analysis_packages_el9 | default(default_leapp_analysis_packages_el9) }}"
 
 # analysis_repos_el6 is deprecated, use leapp_analysis_repos_el6 instead
-# leapp_analysis_repos_el6:
-#   - rhel-6-server-extras-rpms
-#   - rhel-6-server-optional-rpms
-leapp_analysis_repos_el6: "{{ analysis_repos_el6 | default([
-  'rhel-6-server-extras-rpms',
-  'rhel-6-server-optional-rpms'
-]) }}"
+default_leapp_analysis_repos_el6:
+  - rhel-6-server-extras-rpms
+  - rhel-6-server-optional-rpms
+leapp_analysis_repos_el6: "{{ analysis_repos_el6 | default(default_leapp_analysis_repos_el6) }}"
+
 # analysis_repos_el7 is deprecated, use leapp_analysis_repos_el7 instead
-# leapp_analysis_repos_el7:
-#   - rhel-7-server-extras-rpms
-leapp_analysis_repos_el7: "{{ analysis_repos_el7 | default([
-  'rhel-7-server-extras-rpms'
-]) }}"
+default_leapp_analysis_repos_el7:
+  - rhel-7-server-extras-rpms
+leapp_analysis_repos_el7: "{{ analysis_repos_el7 | default(default_leapp_analysis_repos_el7) }}"
 
 # analysis_repos_el8 is deprecated, use leapp_analysis_repos_el8 instead
-# leapp_analysis_repos_el8: []
 leapp_analysis_repos_el8: "{{ analysis_repos_el8 | default([]) }}"
 
 # analysis_repos_el9 is deprecated, use leapp_analysis_repos_el9 instead
-# leapp_analysis_repos_el9: []
 leapp_analysis_repos_el9: "{{ analysis_repos_el9 | default([]) }}"
 
 # If defined, leapp_answerfile will be used as the contents of /var/log/leapp/answerfile.

--- a/roles/analysis/vars/main.yml
+++ b/roles/analysis/vars/main.yml
@@ -1,10 +1,3 @@
 ---
 # vars file for analysis
-__leapp_enable_repos_args: "{{ ('--enablerepo ' + leapp_repos_enabled | default([], true) | join(' --enablerepo '))
-  if leapp_repos_enabled | length > 0 else '' }}"
-
-leapp_result_filename: "{{ '/root/preupgrade/result.txt' if ansible_distribution_major_version == '6'
-  else '/var/log/leapp/leapp-report.txt' }}"
-
-leapp_inhibitors: []
 ...

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -63,4 +63,11 @@ __leapp_preupg_return_codes:
     msg: preupg command not found.  Analysis must be run first.
     fail: true
     inhibited: true
+
+__leapp_enable_repos_args: "{{ ('--enablerepo ' + leapp_repos_enabled | default([], true) | join(' --enablerepo '))
+  if leapp_repos_enabled | length > 0 else '' }}"
+
+leapp_result_filename: "{{ '/root/preupgrade/result.txt' if ansible_distribution_major_version == '6'
+  else '/var/log/leapp/leapp-report.txt' }}"
+
 ...

--- a/roles/remediate/defaults/main.yml
+++ b/roles/remediate/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# defaults file for remedations
+# defaults file for remediations
 
 # reboot_timeout is deprecated, use leapp_reboot_timeout instead
 # leapp_reboot_timeout: 7200
@@ -16,61 +16,12 @@ leapp_post_reboot_delay: "{{ post_reboot_delay | default(120) }}"
 leapp_report_location: /var/log/leapp/leapp-report.json
 
 # remediation_playbooks is deprecated, use leapp_remediation_playbooks instead
-# leapp_remediation_playbooks:
-#   - leapp_cgroups-v1_enabled
-#   - leapp_cifs_detected
-#   - leapp_corrupted_grubenv_file
-#   - leapp_custom_network_scripts_detected
-#   - leapp_deprecated_sshd_directive
-#   - leapp_firewalld_allowzonedrifting
-#   - leapp_firewalld_unsupported_tftp_client
-#   - leapp_legacy_network_configuration
-#   - leapp_loaded_removed_kernel_drivers
-#   - leapp_missing_efibootmgr
-#   - leapp_missing_pkg
-#   - leapp_missing_yum_plugins
-#   - leapp_move_usr_directory
-#   - leapp_multiple_kernels
-#   - leapp_newest_kernel_not_in_use
-#   - leapp_nfs_detected
-#   - leapp_non_persistent_partitions
-#   - leapp_non_standard_openssl_config
-#   - leapp_old_postgresql_data
-#   - leapp_pam_tally2
-#   - leapp_partitions_with_noexec
-#   - leapp_relative_symlinks
-#   - leapp_remote_using_root
-#   - leapp_rpms_with_rsa_sha1_detected
-#   - leapp_unavailable_kde
-#   - leapp_vdo_check_needed
-leapp_remediation_playbooks: "{{ remediation_playbooks | default([
-  'leapp_cgroups-v1_enabled',
-  'leapp_cifs_detected',
-  'leapp_corrupted_grubenv_file',
-  'leapp_custom_network_scripts_detected',
-  'leapp_deprecated_sshd_directive',
-  'leapp_firewalld_allowzonedrifting',
-  'leapp_firewalld_unsupported_tftp_client',
-  'leapp_legacy_network_configuration',
-  'leapp_loaded_removed_kernel_drivers',
-  'leapp_missing_efibootmgr',
-  'leapp_missing_pkg',
-  'leapp_missing_yum_plugins',
-  'leapp_move_usr_directory',
-  'leapp_multiple_kernels',
-  'leapp_newest_kernel_not_in_use',
-  'leapp_nfs_detected',
-  'leapp_non_persistent_partitions',
-  'leapp_non_standard_openssl_config',
-  'leapp_old_postgresql_data',
-  'leapp_pam_tally2',
-  'leapp_partitions_with_noexec',
-  'leapp_relative_symlinks',
-  'leapp_remote_using_root',
-  'leapp_rpms_with_rsa_sha1_detected',
-  'leapp_unavailable_kde',
-  'leapp_vdo_check_needed'
-]) }}"
+# using relative path assumes the variable will be evaluated in the context of a role
+# tasks file in the tasks directory, which is also where the leapp_*.yml files are located
+default_leapp_remediation_playbooks: "{{
+  q('fileglob', 'leapp_*.yml') | map('basename') | map('regex_replace', '[.]yml$', '') | list }}"
+leapp_remediation_playbooks: "{{ remediation_playbooks |
+  default(default_leapp_remediation_playbooks) }}"
 
 # remediation_todo is deprecated, use leapp_remediation_todo instead
 # leapp_remediation_todo: []

--- a/roles/upgrade/vars/main.yml
+++ b/roles/upgrade/vars/main.yml
@@ -1,8 +1,3 @@
 ---
 # vars file for upgrade
-__leapp_enable_repos_args: "{{ ('--enablerepo ' + leapp_repos_enabled | default([], true) | join(' --enablerepo '))
-  if leapp_repos_enabled | length > 0 else '' }}"
-
-leapp_result_filename: "{{ '/root/preupgrade/result.txt' if ansible_distribution_major_version == '6'
-  else '/var/log/leapp/leapp-report.txt' }}"
 ...

--- a/tests/tasks/common_upgrade_tasks.yml
+++ b/tests/tasks/common_upgrade_tasks.yml
@@ -1,5 +1,12 @@
 ---
 # Common upgrade test tasks that can be included in any upgrade test
+# TODO: This is a hack to remove leapp packages before each test to ensure role will install it.
+# This is usually due to the fact that we are not using the right repository for the test, which
+# causes e.g. rhel 8 packages to have a later N-V-R than rhel 9 packages.
+- name: common_upgrade_tasks | Remove leapp packages
+  ansible.builtin.package:
+    name: "{{ leapp_remove_test_packages }}"
+    state: absent
 
 - name: common_upgrade_tasks | Gather setup tasks
   ansible.builtin.find:
@@ -27,7 +34,7 @@
 
 - name: common_upgrade_tasks | Show all inhibitors collected by analysis
   ansible.builtin.debug:
-    var: leapp_inhibitors
+    var: leapp_inhibitors | default([])
 
 - name: common_upgrade_tasks | Extract inhibitor titles
   ansible.builtin.set_fact:

--- a/tests/vars/common_upgrade_vars.yml
+++ b/tests/vars/common_upgrade_vars.yml
@@ -38,4 +38,8 @@ leapp_answerfile: |
 leapp_env_vars:
   LEAPP_UNSUPPORTED: 1
   LEAPP_DEVEL_RPMS_ALL_SIGNED: 1
+
+# Remove these test packages before each test
+leapp_remove_test_packages:
+  - leapp-upgrade
 ...


### PR DESCRIPTION
Instead of suppressing ansible-lint issues in the warn list, fix the issues.

Fix jinja warnings - use default variables for lists instead of jinja

remove leapp-upgrade package before each test to ensure role will install it

remove leapp_inhibitors from vars file - it is a set_fact

get default remediations by reading files from remediation tasks directory

move common variables from analysis and upgrade into common

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
