### PR TITLE
fix: remove timeout keyword for reboot - it is not correct

### DIFF
--- a/changelogs/fragments/fix_reboot_no_timeout_keyword.yml
+++ b/changelogs/fragments/fix_reboot_no_timeout_keyword.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - The reboot module does not use the `timeout` keyword.
+...

--- a/roles/remediate/handlers/main.yml
+++ b/roles/remediate/handlers/main.yml
@@ -15,6 +15,5 @@
   ansible.builtin.reboot:
     reboot_timeout: "{{ leapp_reboot_timeout }}"
     post_reboot_delay: "{{ leapp_post_reboot_delay }}"
-  timeout: "{{ leapp_reboot_timeout }}"
 
 ...

--- a/roles/remediate/tasks/leapp_multiple_kernels.yml
+++ b/roles/remediate/tasks/leapp_multiple_kernels.yml
@@ -23,7 +23,6 @@
       ansible.builtin.reboot:
         reboot_timeout: "{{ leapp_reboot_timeout }}"
         post_reboot_delay: "{{ leapp_post_reboot_delay }}"
-      timeout: "{{ leapp_reboot_timeout }}"
       when: installed_kernels.stdout_lines[0] != current_kernel.stdout
 
     # TODO: This is slow.  Instead, use filters/map to construct the list

--- a/roles/remediate/tasks/leapp_newest_kernel_not_in_use.yml
+++ b/roles/remediate/tasks/leapp_newest_kernel_not_in_use.yml
@@ -32,6 +32,5 @@
           ansible.builtin.reboot:
             reboot_timeout: "{{ leapp_reboot_timeout }}"
             post_reboot_delay: "{{ leapp_post_reboot_delay }}"
-          timeout: "{{ leapp_reboot_timeout }}"
 
 ...

--- a/roles/upgrade/tasks/grub2-upgrade.yml
+++ b/roles/upgrade/tasks/grub2-upgrade.yml
@@ -62,6 +62,5 @@
   ansible.builtin.reboot:
     reboot_timeout: "{{ leapp_reboot_timeout }}"
     post_reboot_delay: "{{ leapp_post_reboot_delay }}"
-  timeout: "{{ leapp_reboot_timeout }}"
 
 ...

--- a/roles/upgrade/tasks/leapp-post-upgrade-selinux.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade-selinux.yml
@@ -18,7 +18,6 @@
   ansible.builtin.reboot:
     reboot_timeout: "{{ leapp_reboot_timeout }}"
     post_reboot_delay: "{{ leapp_post_reboot_delay }}"
-  timeout: "{{ leapp_reboot_timeout }}"
   when: selinux_results.reboot_required
 
 - name: leapp-post-upgrade-selinux | Verify SELinux is set to {{ leapp_selinux_mode }}

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -124,7 +124,6 @@
     msg: Host is starting Leapp OS upgrade now!
     reboot_timeout: "{{ leapp_upgrade_timeout }}"
     post_reboot_delay: "{{ leapp_post_reboot_delay }}"
-  timeout: "{{ leapp_upgrade_timeout }}"
 
 # Ansible discovers /usr/bin/python on RHEL 7, then on RHEL 8 it is no longer available.
 - name: leapp-upgrade | Set python interpreter to /usr/libexec/platform-python since /usr/bin/python is no longer available
@@ -156,6 +155,5 @@
       ansible.builtin.reboot:
         reboot_timeout: "{{ leapp_reboot_timeout }}"
         post_reboot_delay: "{{ leapp_post_reboot_delay }}"
-      timeout: "{{ leapp_reboot_timeout }}"
 
 ...

--- a/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
@@ -104,6 +104,5 @@
     msg: Host is starting OS upgrade now!
     reboot_timeout: "{{ leapp_upgrade_timeout }}"
     post_reboot_delay: "{{ leapp_post_reboot_delay }}"
-  timeout: "{{ leapp_upgrade_timeout }}"
 
 ...

--- a/roles/upgrade/tasks/update-and-reboot.yml
+++ b/roles/upgrade/tasks/update-and-reboot.yml
@@ -11,7 +11,6 @@
   ansible.builtin.reboot:
     reboot_timeout: "{{ leapp_reboot_timeout }}"
     post_reboot_delay: "{{ leapp_post_reboot_delay }}"
-  timeout: "{{ leapp_reboot_timeout }}"
   when: updates_available.changed # noqa: no-handler
 
 ...


### PR DESCRIPTION
There were several `reboot` modules using a `timeout` keyword.
There is no such keyword - https://docs.ansible.com/projects/ansible/latest/reference_appendices/playbooks_keywords.html
The `reboot` used in this collection already use the `reboot_timeout` and
other timeout parameters - https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/reboot_module.html
It's possible that the `timeout` was left over from some very old version of Ansible.

Fixes https://github.com/redhat-cop/infra.leapp/issues/321

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
