### PR TITLE
fix: use split method instead of filter for 2.9 support

### DIFF
--- a/changelogs/fragments/fix-do-not-use-split-filter.yml
+++ b/changelogs/fragments/fix-do-not-use-split-filter.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - Use the split string method instead of the filter for 2.9 support.
+
+...

--- a/roles/common/tasks/parse_leapp_report.yml
+++ b/roles/common/tasks/parse_leapp_report.yml
@@ -26,7 +26,7 @@
     - name: parse_leapp_report | Parse report results
       ansible.builtin.set_fact:
         cacheable: "{{ leapp_result_fact_cacheable }}"
-        leapp_report_txt: "{{ results_txt.content | b64decode | split('\n') }}"
+        leapp_report_txt: "{{ (results_txt.content | b64decode).split('\n') | list }}"
         leapp_report_json: "{{ results_json.content | b64decode | from_json }}"
 
     - name: parse_leapp_report | Check for inhibitors

--- a/roles/remediate/tasks/leapp_corrupted_grubenv_file.yml
+++ b/roles/remediate/tasks/leapp_corrupted_grubenv_file.yml
@@ -22,7 +22,7 @@
     - name: leapp_corrupted_grubenv_file | Process remediation
       when: hint | length > 0
       vars:
-        files_grub: "{{ hint.context | regex_findall('Delete (.+?) file', '\\1') | first | split(',') | map('trim') }}"
+        files_grub: "{{ (hint.context | regex_findall('Delete (.+?) file', '\\1') | first).split(',') | map('trim') | list }}"
       block:
         - name: leapp_corrupted_grubenv_file | Backup file(s)
           ansible.builtin.copy:

--- a/roles/remediate/tasks/leapp_nfs_detected.yml
+++ b/roles/remediate/tasks/leapp_nfs_detected.yml
@@ -24,13 +24,13 @@
       block:
         - name: leapp_nfs_detected | Get fstab_entries
           ansible.builtin.set_fact:
-            fstab_entries: "{{ item | split('- NFS shares found in /etc/fstab:') | last | trim | regex_findall('- ([^ ]+)', '\\1') }}"
+            fstab_entries: "{{ item.split('- NFS shares found in /etc/fstab:') | last | trim | regex_findall('- ([^ ]+)', '\\1') | list }}"
           loop: "{{ split_summary }}"
           when: "'- NFS shares found in /etc/fstab:' in item"
 
         - name: leapp_nfs_detected | Get nfs_mounts
           ansible.builtin.set_fact:
-            nfs_mounts: "{{ item | split('- NFS shares currently mounted:') | last | trim | regex_findall('- ([^ ]+)', '\\1') }}"
+            nfs_mounts: "{{ item.split('- NFS shares currently mounted:') | last | trim | regex_findall('- ([^ ]+)', '\\1') | list }}"
           loop: "{{ split_summary }}"
           when: "'- NFS shares currently mounted:' in item"
 

--- a/roles/remediate/tasks/leapp_rpms_with_rsa_sha1_detected.yml
+++ b/roles/remediate/tasks/leapp_rpms_with_rsa_sha1_detected.yml
@@ -25,7 +25,7 @@
       block:
         - name: leapp_rpms_with_rsa_sha1_detected | Parse bad_pkgs
           ansible.builtin.set_fact:
-            bad_pkgs: "{{ summary | split('The list of problematic packages:') | last | trim | regex_findall('- ([^ ]+)', '\\1') }}"
+            bad_pkgs: "{{ summary.split('The list of problematic packages:') | last | trim | regex_findall('- ([^ ]+)', '\\1') | list }}"
 
         # TODO: Pass the bad_pkgs list directly to the dnf command?  Is there some reason
         # this has to be done one at a time?  It is much slower this way.


### PR DESCRIPTION
The `split` filter was added in 2.11, so we cannot use it in Ansible 2.9.
Instead, use the `split` string method.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
