### PR TITLE
fix: convert pipeline to list with first for Ansible 2.9 support

### DIFF
--- a/changelogs/fragments/fix_convert_to_list_first_2.9.yml
+++ b/changelogs/fragments/fix_convert_to_list_first_2.9.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - Convert pipeline to list and use first to get first element for Ansible 2.9 support
+
+...

--- a/roles/upgrade/tasks/leapp-upgrade-validation.yml
+++ b/roles/upgrade/tasks/leapp-upgrade-validation.yml
@@ -15,7 +15,7 @@
       (migration_results_json.activities |
       selectattr('activity', 'match', 'upgrade') |
       selectattr('target_os', 'match', 'Red Hat Enterprise Linux ' + ansible_distribution_major_version) |
-      selectattr('env.LEAPP_CURRENT_PHASE', 'match', 'FirstBoot'))[0].success
+      selectattr('env.LEAPP_CURRENT_PHASE', 'match', 'FirstBoot') | list | first).success
       }}
 
 - name: leapp-upgrade-validation | Ensure that Leapp upgrade FirstBoot was successful


### PR DESCRIPTION
Ansible 2.9 support requires sending the pipeline through `list` and `first`

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
