### PR TITLE
tests: Update RHEL versions in tests to 9.7 and 10.1

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -111,7 +111,7 @@ jobs:
             compose_managed_node: RHEL-8.10.0-Nightly
           - ansible_version: 2.17
             compose_controller: RHEL-9-Nightly
-            compose_managed_node: RHEL-9.6.0-Nightly
+            compose_managed_node: RHEL-9.7.0-Nightly
     runs-on: ubuntu-latest
     steps:
       - name: Set variables with DATETIME and artifact location
@@ -201,12 +201,12 @@ jobs:
             RHEL_7_9_EXTRAS_REPO_URL=${{ secrets.RHEL_7_9_EXTRAS_REPO_URL }};\
             RHEL_8_10_BASEOS_REPO_URL=${{ secrets.RHEL_8_10_BASEOS_REPO_URL }};\
             RHEL_8_10_APPSTREAM_REPO_URL=${{ secrets.RHEL_8_10_APPSTREAM_REPO_URL }};\
-            RHEL_9_6_BASEOS_REPO_URL=${{ secrets.RHEL_9_6_BASEOS_REPO_URL }};\
-            RHEL_9_6_APPSTREAM_REPO_URL=${{ secrets.RHEL_9_6_APPSTREAM_REPO_URL }};\
-            RHEL_9_8_BASEOS_REPO_URL=${{ secrets.RHEL_9_8_BASEOS_REPO_URL }};\
-            RHEL_9_8_APPSTREAM_REPO_URL=${{ secrets.RHEL_9_8_APPSTREAM_REPO_URL }};\
-            RHEL_10_0_BASEOS_REPO_URL=${{ secrets.RHEL_10_0_BASEOS_REPO_URL }};\
-            RHEL_10_0_APPSTREAM_REPO_URL=${{ secrets.RHEL_10_0_APPSTREAM_REPO_URL }};\
+            RHEL_9_7_BASEOS_REPO_URL=${{ secrets.RHEL_9_7_BASEOS_REPO_URL }};\
+            RHEL_9_7_APPSTREAM_REPO_URL=${{ secrets.RHEL_9_7_APPSTREAM_REPO_URL }};\
+            RHEL_10_1_BASEOS_REPO_URL=${{ secrets.RHEL_10_1_BASEOS_REPO_URL }};\
+            RHEL_10_1_APPSTREAM_REPO_URL=${{ secrets.RHEL_10_1_APPSTREAM_REPO_URL }};\
+            RHEL_9_LATEST_BASEOS_REPO_URL=${{ secrets.RHEL_9_NIGHTLY_BASEOS_REPO_URL }};\
+            RHEL_9_LATEST_APPSTREAM_REPO_URL=${{ secrets.RHEL_9_NIGHTLY_APPSTREAM_REPO_URL }};\
             BEAKERLIB_HARNESS_URL_NO_VER=${{ secrets.BEAKERLIB_HARNESS_URL_NO_VER }};\
             SR_ARTIFACTS_URL=${{ steps.set_vars.outputs.ARTIFACTS_URL }}"
           tmt_context: "initiator=testing-farm"

--- a/plans/test_playbooks.fmf
+++ b/plans/test_playbooks.fmf
@@ -17,7 +17,7 @@ adjust:
         role: control_node
         how: virtual
         connection: system
-        image: ${RHEL_9_8_image}
+        image: ${RHEL_9_latest_image}
   - when: >-
       initiator is not defined
       and 1minutetip is not defined
@@ -47,7 +47,7 @@ adjust:
         role: managed_node
         how: virtual
         connection: system
-        image: ${RHEL_9_6_image}
+        image: ${RHEL_9_7_image}
 
   # Running locally by provisioning 1minutetip VMs. Example run:
   # tmt -c 1minutetip=true -c COMPOSE_MANAGED_NODE=rhel8 try -p /plans/test_playbooks

--- a/tests/tmt/test_playbooks/test_playbooks.sh
+++ b/tests/tmt/test_playbooks/test_playbooks.sh
@@ -147,10 +147,10 @@ rlJournalStart
         [ -n "$RHEL_7_9_EXTRAS_REPO_URL" ] && sed -i "s|__RHEL_7_9_EXTRAS_REPO_URL__|$RHEL_7_9_EXTRAS_REPO_URL|g" "$repo_vars_file"
         [ -n "$RHEL_8_10_BASEOS_REPO_URL" ] && sed -i "s|__RHEL_8_10_BASEOS_REPO_URL__|$RHEL_8_10_BASEOS_REPO_URL|g" "$repo_vars_file"
         [ -n "$RHEL_8_10_APPSTREAM_REPO_URL" ] && sed -i "s|__RHEL_8_10_APPSTREAM_REPO_URL__|$RHEL_8_10_APPSTREAM_REPO_URL|g" "$repo_vars_file"
-        [ -n "$RHEL_9_6_BASEOS_REPO_URL" ] && sed -i "s|__RHEL_9_6_BASEOS_REPO_URL__|$RHEL_9_6_BASEOS_REPO_URL|g" "$repo_vars_file"
-        [ -n "$RHEL_9_6_APPSTREAM_REPO_URL" ] && sed -i "s|__RHEL_9_6_APPSTREAM_REPO_URL__|$RHEL_9_6_APPSTREAM_REPO_URL|g" "$repo_vars_file"
-        [ -n "$RHEL_10_0_BASEOS_REPO_URL" ] && sed -i "s|__RHEL_10_0_BASEOS_REPO_URL__|$RHEL_10_0_BASEOS_REPO_URL|g" "$repo_vars_file"
-        [ -n "$RHEL_10_0_APPSTREAM_REPO_URL" ] && sed -i "s|__RHEL_10_0_APPSTREAM_REPO_URL__|$RHEL_10_0_APPSTREAM_REPO_URL|g" "$repo_vars_file"
+        [ -n "$RHEL_9_7_BASEOS_REPO_URL" ] && sed -i "s|__RHEL_9_7_BASEOS_REPO_URL__|$RHEL_9_7_BASEOS_REPO_URL|g" "$repo_vars_file"
+        [ -n "$RHEL_9_7_APPSTREAM_REPO_URL" ] && sed -i "s|__RHEL_9_7_APPSTREAM_REPO_URL__|$RHEL_9_7_APPSTREAM_REPO_URL|g" "$repo_vars_file"
+        [ -n "$RHEL_10_1_BASEOS_REPO_URL" ] && sed -i "s|__RHEL_10_1_BASEOS_REPO_URL__|$RHEL_10_1_BASEOS_REPO_URL|g" "$repo_vars_file"
+        [ -n "$RHEL_10_1_APPSTREAM_REPO_URL" ] && sed -i "s|__RHEL_10_1_APPSTREAM_REPO_URL__|$RHEL_10_1_APPSTREAM_REPO_URL|g" "$repo_vars_file"
         rlRun "cat $repo_vars_file"
         leappDebugRepos
 

--- a/tests/vars/repo_urls.yml
+++ b/tests/vars/repo_urls.yml
@@ -13,12 +13,12 @@ repo_urls:
       url: "__RHEL_8_10_APPSTREAM_REPO_URL__"
   rhel9:
     baseos:
-      url: "__RHEL_9_6_BASEOS_REPO_URL__"
+      url: "__RHEL_9_7_BASEOS_REPO_URL__"
     appstream:
-      url: "__RHEL_9_6_APPSTREAM_REPO_URL__"
+      url: "__RHEL_9_7_APPSTREAM_REPO_URL__"
   rhel10:
     baseos:
-      url: "__RHEL_10_0_BASEOS_REPO_URL__"
+      url: "__RHEL_10_1_BASEOS_REPO_URL__"
     appstream:
-      url: "__RHEL_10_0_APPSTREAM_REPO_URL__"
+      url: "__RHEL_10_1_APPSTREAM_REPO_URL__"
 ...


### PR DESCRIPTION
RHEL 9.7 and 10.1 was GA in November.
Also, use a general "latest" wording for RHEL 9 on the control node as for the control node we always use the latest beta RHEL 9.

This change is depended on an MR#15 in tests-ansible-collection-leapp