### PR TITLE
refactor: handle INJECT_FACTS_AS_VARS=false by using ansible_facts instead

### DIFF
--- a/changelogs/fragments/refactor_inject_facts_as_vars_false.yml
+++ b/changelogs/fragments/refactor_inject_facts_as_vars_false.yml
@@ -1,0 +1,4 @@
+minor_changes:
+    - refactor - handle INJECT_FACTS_AS_VARS=false by using ansible_facts instead
+
+...

--- a/roles/analysis/defaults/main.yml
+++ b/roles/analysis/defaults/main.yml
@@ -60,7 +60,7 @@ leapp_satellite_activation_key_pre_leapp: null
 leapp_satellite_activation_key_leapp: null
 
 # leapp_repos_enabled:
-#   - satellite-client-6-for-rhel-{{ ansible_distribution_major_version | int + 1 }}-x86_64-rpms
+#   - satellite-client-6-for-rhel-{{ ansible_facts['distribution_major_version'] | int + 1 }}-x86_64-rpms
 leapp_repos_enabled: []
 
 # Treat all high risk findings as inhibitors, not just those exclusively marked as inhibitors by Leapp

--- a/roles/analysis/tasks/analysis-leapp.yml
+++ b/roles/analysis/tasks/analysis-leapp.yml
@@ -24,21 +24,21 @@
     name: "{{ leapp_analysis_packages_el7 }}"
     enablerepo: "{{ leapp_analysis_repos_el7 }}"
     state: latest # noqa package-latest
-  when: ansible_distribution_major_version|int == 7
+  when: ansible_facts["distribution_major_version"]|int == 7
 
 - name: analysis-leapp | Install packages for preupgrade analysis on RHEL 8
   ansible.builtin.package:
     name: "{{ leapp_analysis_packages_el8 }}"
     enablerepo: "{{ leapp_analysis_repos_el8 }}"
     state: latest # noqa package-latest
-  when: ansible_distribution_major_version|int == 8
+  when: ansible_facts["distribution_major_version"]|int == 8
 
 - name: analysis-leapp | Install packages for preupgrade analysis on RHEL 9
   ansible.builtin.package:
     name: "{{ leapp_analysis_packages_el9 }}"
     enablerepo: "{{ leapp_analysis_repos_el9 }}"
     state: latest # noqa package-latest
-  when: ansible_distribution_major_version|int == 9
+  when: ansible_facts["distribution_major_version"]|int == 9
 
 - name: analysis-leapp | Ensure leapp log directory exists
   ansible.builtin.file:

--- a/roles/analysis/tasks/main.yml
+++ b/roles/analysis/tasks/main.yml
@@ -8,11 +8,11 @@
 
 - name: Include tasks for preupg assistant analysis
   ansible.builtin.include_tasks: analysis-preupg.yml
-  when: ansible_distribution_major_version|int == 6
+  when: ansible_facts["distribution_major_version"]|int == 6
 
 - name: Include tasks for leapp preupgrade analysis
   ansible.builtin.include_tasks: analysis-leapp.yml
-  when: ansible_distribution_major_version|int >= 7
+  when: ansible_facts["distribution_major_version"]|int >= 7
 
 - name: Set stats for leapp_inhibitors
   ansible.builtin.set_stats:

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -32,7 +32,7 @@
 - name: Rename log file
   ansible.builtin.shell: |
     export PATH={{ leapp_os_path }}
-    mv {{ leapp_log_file }} {{ leapp_log_file }}-{{ ansible_date_time.iso8601_basic_short }}
+    mv {{ leapp_log_file }} {{ leapp_log_file }}-{{ ansible_facts['date_time'].iso8601_basic_short }}
   listen: Archive log file
   changed_when: true
   when: log_file_stat.stat.exists

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -53,7 +53,7 @@
     cmd: >-
       set -o pipefail;
       export PATH={{ leapp_os_path }};
-      rpm -qa | grep -ve '[\.|+]el{{ ansible_distribution_major_version }}' |
+      rpm -qa | grep -ve '[\.|+]el{{ ansible_facts['distribution_major_version'] }}' |
       grep -vE '^(gpg-pubkey|libmodulemd|katello-ca-consumer)' |
       sort
   register: unsigned_packages_pre

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -67,7 +67,7 @@ __leapp_preupg_return_codes:
 __leapp_enable_repos_args: "{{ ('--enablerepo ' + leapp_repos_enabled | default([], true) | join(' --enablerepo '))
   if leapp_repos_enabled | length > 0 else '' }}"
 
-leapp_result_filename: "{{ '/root/preupgrade/result.txt' if ansible_distribution_major_version == '6'
+leapp_result_filename: "{{ '/root/preupgrade/result.txt' if ansible_facts['distribution_major_version'] == '6'
   else '/var/log/leapp/leapp-report.txt' }}"
 
 ...

--- a/roles/remediate/tasks/leapp_cgroups-v1_enabled.yml
+++ b/roles/remediate/tasks/leapp_cgroups-v1_enabled.yml
@@ -13,8 +13,8 @@
       if remediation_matches | length > 0 else {} }}"
   when:
     - not leapp_report_missing | default(false)
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version | int == 9
+    - ansible_facts['distribution'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | int == 9
   block:
     - name: leapp_cgroups-v1_enabled | End remediation if a matching entry was not found in the leapp report
       ansible.builtin.debug:

--- a/roles/remediate/tasks/leapp_custom_network_scripts_detected.yml
+++ b/roles/remediate/tasks/leapp_custom_network_scripts_detected.yml
@@ -1,8 +1,8 @@
 ---
 - name: leapp_custom_network_scripts_detected | Move custom network-scripts to NetworkManager dispatcher scripts
   when:
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version | int == 8
+    - ansible_facts['distribution'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | int == 8
   block:
     - name: leapp_custom_network_scripts_detected | Check if pre up script exists
       ansible.builtin.stat:

--- a/roles/remediate/tasks/leapp_deprecated_sshd_directive.yml
+++ b/roles/remediate/tasks/leapp_deprecated_sshd_directive.yml
@@ -14,8 +14,8 @@
     remediation: "{{ commands | first if commands | length > 0 else {} }}"
   when:
     - not leapp_report_missing | default(false)
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version | int == 8
+    - ansible_facts['distribution'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | int == 8
   block:
     - name: leapp_deprecated_sshd_directive | End execution of playbook if no entry found in leapp report
       ansible.builtin.debug:

--- a/roles/remediate/tasks/leapp_firewalld_allowzonedrifting.yml
+++ b/roles/remediate/tasks/leapp_firewalld_allowzonedrifting.yml
@@ -1,8 +1,8 @@
 ---
 - name: leapp_firewalld_allowzonedrifting | Set the "AllowZoneDrifting" in firewalld.conf to "no"
   when:
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version | int == 8
+    - ansible_facts['distribution'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | int == 8
   block:
     - name: leapp_firewalld_allowzonedrifting | Set the "AllowZoneDrifting" in firewalld.conf to "no"
       ansible.builtin.lineinfile:

--- a/roles/remediate/tasks/leapp_firewalld_unsupported_tftp_client.yml
+++ b/roles/remediate/tasks/leapp_firewalld_unsupported_tftp_client.yml
@@ -13,8 +13,8 @@
     summary: "{{ summaries | first if summaries | length > 0 else '' }}"
   when:
     - not leapp_report_missing | default(false)
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version | int == 8
+    - ansible_facts['distribution'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | int == 8
   block:
     - name: leapp_firewalld_unsupported_tftp_client | End execution of playbook if no entry found in leapp report
       ansible.builtin.debug:

--- a/roles/remediate/tasks/leapp_legacy_network_configuration.yml
+++ b/roles/remediate/tasks/leapp_legacy_network_configuration.yml
@@ -13,8 +13,8 @@
       if remediation_matches | length > 0 else {} }}"
   when:
     - not leapp_report_missing | default(false)
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version | int == 9
+    - ansible_facts['distribution'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | int == 9
   block:
     - name: leapp_legacy_network_configuration | End remediation if a matching entry was not found in the leapp report
       ansible.builtin.debug:

--- a/roles/remediate/tasks/leapp_move_usr_directory.yml
+++ b/roles/remediate/tasks/leapp_move_usr_directory.yml
@@ -9,13 +9,13 @@
   vars:
     entry_title: The /usr/ directory is located on a separate partition. The in-place upgrade is not possible.
     entry_found: "{{ entry_title in (leapp_pre_upgrade_report_6to7.content | b64decode) }}"
-    usr_local_mount_source: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr/local') | map(attribute='device') | d([''], true) | first }}"
-    usr_mount_source: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr') | map(attribute='device') | d([''], true) | first }}"
-    root_mount_source: "{{ ansible_mounts | selectattr('mount', 'eq', '/') | map(attribute='device') | d([''], true) | first }}"
+    usr_local_mount_source: "{{ ansible_facts['mounts'] | selectattr('mount', 'eq', '/usr/local') | map(attribute='device') | d([''], true) | first }}"
+    usr_mount_source: "{{ ansible_facts['mounts'] | selectattr('mount', 'eq', '/usr') | map(attribute='device') | d([''], true) | first }}"
+    root_mount_source: "{{ ansible_facts['mounts'] | selectattr('mount', 'eq', '/') | map(attribute='device') | d([''], true) | first }}"
   when:
     - not leapp_report_missing_6to7 | default(false)
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version | int == 6
+    - ansible_facts['distribution'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | int == 6
   block:
     - name: leapp_move_usr_directory | End execution of playbook if no entry found in leapp report
       ansible.builtin.debug:
@@ -48,19 +48,19 @@
         - name: leapp_move_usr_directory | Check available space on root filesystem
           ansible.builtin.set_fact:
             root_space: "{{ item.block_available * item.block_size }}"
-          loop: "{{ ansible_mounts }}"
+          loop: "{{ ansible_facts['mounts'] }}"
           when: item.mount == '/'
 
         - name: leapp_move_usr_directory | Get /usr size
           ansible.builtin.set_fact:
             usr_size: "{{ item.block_available * item.block_size }}"
-          loop: "{{ ansible_mounts }}"
+          loop: "{{ ansible_facts['mounts'] }}"
           when: item.mount == '/usr'
 
         - name: leapp_move_usr_directory | Get /usr/local size
           ansible.builtin.set_fact:
             usr_local_size: "{{ item.block_available * item.block_size }}"
-          loop: "{{ ansible_mounts }}"
+          loop: "{{ ansible_facts['mounts'] }}"
           when: item.mount == '/usr/local' and usr_local_mount_source | length > 0
 
         - name: leapp_move_usr_directory | Check if enough space on root filesystem

--- a/roles/remediate/tasks/leapp_non_standard_openssl_config.yml
+++ b/roles/remediate/tasks/leapp_non_standard_openssl_config.yml
@@ -1,8 +1,8 @@
 ---
 - name: leapp_non_standard_openssl_config | Adjust openssl.cnf configuration for default_modules
   when:
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version | int == 8
+    - ansible_facts['distribution'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | int == 8
   vars:
     openssl_cnf_path: /etc/pki/tls/openssl.cnf
   block:

--- a/roles/remediate/tasks/leapp_old_postgresql_data.yml
+++ b/roles/remediate/tasks/leapp_old_postgresql_data.yml
@@ -31,6 +31,6 @@
             remove: true
             mode: "0755"
           vars:
-            backup_filename: pgsql_data_backup_{{ ansible_date_time.iso8601_basic_short }}.tar.gz
+            backup_filename: pgsql_data_backup_{{ ansible_facts['date_time'].iso8601_basic_short }}.tar.gz
 
 ...

--- a/roles/remediate/tasks/leapp_pam_tally2.yml
+++ b/roles/remediate/tasks/leapp_pam_tally2.yml
@@ -2,8 +2,8 @@
 - name: leapp_pam_tally2 | Remove pam_tally2 modules
   # pam_tally2 only existed in RHEL 5-7, skip if this is not a RHEL 7 upgrade
   when:
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version | int == 7
+    - ansible_facts['distribution'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | int == 7
   block:
     - name: leapp_pam_tally2 | Find all instances of pam_tally2 in /etc/pam.d/
       ansible.builtin.find:

--- a/roles/remediate/tasks/leapp_rpms_with_rsa_sha1_detected.yml
+++ b/roles/remediate/tasks/leapp_rpms_with_rsa_sha1_detected.yml
@@ -12,8 +12,8 @@
     summary: "{{ summaries | first if summaries | length > 0 else '' }}"
   when:
     - not leapp_report_missing | default(false)
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version | int == 8
+    - ansible_facts['distribution'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | int == 8
   block:
     - name: leapp_rpms_with_rsa_sha1_detected | End execution of playbook if no entry found in leapp report
       ansible.builtin.debug:

--- a/roles/remediate/tasks/leapp_unavailable_kde.yml
+++ b/roles/remediate/tasks/leapp_unavailable_kde.yml
@@ -3,8 +3,8 @@
 # We will only install the gnome desktop environment if KDE is installed
 - name: leapp_unavailable_kde | Install the GNOME desktop environment to be able to upgrade
   when:
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version | int == 7
+    - ansible_facts['distribution'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | int == 7
   block:
     - name: leapp_unavailable_kde | Check if the KDE desktop environment is installed
       ansible.builtin.command: # noqa: command-instead-of-module

--- a/roles/remediate/tasks/leapp_vdo_check_needed.yml
+++ b/roles/remediate/tasks/leapp_vdo_check_needed.yml
@@ -1,8 +1,8 @@
 ---
 - name: leapp_vdo_check_needed | Install vdo package - required for performing the VDO check of block devices
   when:
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version | int == 8
+    - ansible_facts['distribution'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | int == 8
   block:
     - name: leapp_vdo_check_needed | Install vdo package
       ansible.builtin.dnf:

--- a/roles/upgrade/defaults/main.yml
+++ b/roles/upgrade/defaults/main.yml
@@ -37,7 +37,7 @@ leapp_upgrade_opts: "{{ '--no-rhsm' if leapp_upgrade_type == 'rhui' or leapp_upg
 
 leapp_repos_enabled: []
 # leapp_repos_enabled:
-#   - satellite-client-6-for-rhel-{{ ansible_distribution_major_version | int + 1 }}-x86_64-rpms
+#   - satellite-client-6-for-rhel-{{ ansible_facts['distribution_major_version'] | int + 1 }}-x86_64-rpms
 
 # rhel_7_network_install_repo_url is deprecated, use leapp_rhel_7_network_install_repo_url instead
 # leapp_rhel_7_network_install_repo_url: http://capsule1.example.com/pub/ISO/RHEL7.9
@@ -229,7 +229,7 @@ leapp_kernel_modules_to_unload_before_upgrade: "{{ kernel_modules_to_unload_befo
 # Note: Leaving the deprecated 'post_7_to_8_python_interpreter' variable functional for now.
 leapp_post_upgrade_python_interpreter: >-
   {{ post_7_to_8_python_interpreter
-     if (ansible_distribution_major_version == '7'
+     if (ansible_facts['distribution_major_version'] == '7'
          and post_7_to_8_python_interpreter is defined)
      else '/usr/libexec/platform-python' }}
 

--- a/roles/upgrade/tasks/disable-previous-repo-files.yml
+++ b/roles/upgrade/tasks/disable-previous-repo-files.yml
@@ -11,7 +11,7 @@
       ansible.builtin.copy:
         remote_src: true
         src: /etc/yum.repos.d/{{ item }}
-        dest: /etc/yum.repos.d/{{ item }}.{{ ansible_date_time.iso8601_basic_short }}
+        dest: /etc/yum.repos.d/{{ item }}.{{ ansible_facts['date_time'].iso8601_basic_short }}
         owner: root
         group: root
         mode: "0644"

--- a/roles/upgrade/tasks/grub2-upgrade.yml
+++ b/roles/upgrade/tasks/grub2-upgrade.yml
@@ -23,16 +23,16 @@
   block:
     - name: grub2-upgrade | Determine if /boot is a mount point
       ansible.builtin.set_fact:
-        boot_mounted: "{{ ansible_mounts | selectattr('mount', 'eq', '/boot') | list | length | bool }}"
+        boot_mounted: "{{ ansible_facts['mounts'] | selectattr('mount', 'eq', '/boot') | list | length | bool }}"
 
     - name: grub2-upgrade | Get boot device dict from /boot
       ansible.builtin.set_fact:
-        boot_device_dict: "{{ ansible_mounts | selectattr('mount', 'eq', '/boot') | list | first }}"
+        boot_device_dict: "{{ ansible_facts['mounts'] | selectattr('mount', 'eq', '/boot') | list | first }}"
       when: boot_mounted
 
     - name: grub2-upgrade | Get boot device dict from /
       ansible.builtin.set_fact:
-        boot_device_dict: "{{ ansible_mounts | selectattr('mount', 'eq', '/') | list | first }}"
+        boot_device_dict: "{{ ansible_facts['mounts'] | selectattr('mount', 'eq', '/') | list | first }}"
       when: not boot_mounted
 
     - name: grub2-upgrade | Get boot device from boot device dict

--- a/roles/upgrade/tasks/handle-old-packages.yml
+++ b/roles/upgrade/tasks/handle-old-packages.yml
@@ -6,7 +6,7 @@
       set -o pipefail;
       export PATH={{ leapp_os_path }};
       rpm -qa |
-      grep -ve '[\.|+]el{{ ansible_distribution_major_version }}' |
+      grep -ve '[\.|+]el{{ ansible_facts['distribution_major_version'] }}' |
       grep -vE '^(gpg-pubkey|libmodulemd|katello-ca-consumer)' |
       sort
   register: unsigned_packages_post
@@ -61,6 +61,6 @@
     state: absent
   when:
     - leapp_remove_old_rhel_packages
-    - ansible_distribution_major_version | int >= 7
+    - ansible_facts["distribution_major_version"] | int >= 7
 
 ...

--- a/roles/upgrade/tasks/leapp-post-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade.yml
@@ -76,8 +76,8 @@
     name:
       - leapp
       - leapp-deps
-      - leapp-deps-el{{ ansible_distribution_major_version }}
-      - leapp-repository-deps-el{{ ansible_distribution_major_version }}
+      - leapp-deps-el{{ ansible_facts['distribution_major_version'] }}
+      - leapp-repository-deps-el{{ ansible_facts['distribution_major_version'] }}
       - kernel-workaround
       - python2-leapp
     state: absent

--- a/roles/upgrade/tasks/leapp-upgrade-validation.yml
+++ b/roles/upgrade/tasks/leapp-upgrade-validation.yml
@@ -14,7 +14,7 @@
       {{
       (migration_results_json.activities |
       selectattr('activity', 'match', 'upgrade') |
-      selectattr('target_os', 'match', 'Red Hat Enterprise Linux ' + ansible_distribution_major_version) |
+      selectattr('target_os', 'match', 'Red Hat Enterprise Linux ' + ansible_facts['distribution_major_version']) |
       selectattr('env.LEAPP_CURRENT_PHASE', 'match', 'FirstBoot') | list | first).success
       }}
 

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -50,21 +50,21 @@
     name: "{{ leapp_upgrade_packages_el7 }}"
     enablerepo: "{{ leapp_upgrade_repos_el7 }}"
     state: latest # noqa package-latest
-  when: ansible_distribution_major_version|int == 7
+  when: ansible_facts["distribution_major_version"]|int == 7
 
 - name: leapp-upgrade | Install packages for upgrade from RHEL 8
   ansible.builtin.package:
     name: "{{ leapp_upgrade_packages_el8 }}"
     enablerepo: "{{ leapp_upgrade_repos_el8 }}"
     state: latest # noqa package-latest
-  when: ansible_distribution_major_version|int == 8
+  when: ansible_facts["distribution_major_version"]|int == 8
 
 - name: leapp-upgrade | Install packages for upgrade from RHEL 9
   ansible.builtin.package:
     name: "{{ leapp_upgrade_packages_el9 }}"
     enablerepo: "{{ leapp_upgrade_repos_el9 }}"
     state: latest # noqa package-latest
-  when: ansible_distribution_major_version|int == 9
+  when: ansible_facts["distribution_major_version"]|int == 9
 
 - name: leapp-upgrade | Include update-and-reboot.yml
   ansible.builtin.include_tasks: update-and-reboot.yml
@@ -145,7 +145,7 @@
 - name: leapp-upgrade | Set python interpreter to /usr/libexec/platform-python since /usr/bin/python is no longer available
   ansible.builtin.set_fact:
     ansible_python_interpreter: "{{ leapp_post_upgrade_python_interpreter }}"
-  when: ansible_distribution_major_version | int >= 7
+  when: ansible_facts["distribution_major_version"] | int >= 7
 
 - name: leapp-upgrade | Wait for leapp_resume run once service to no longer exist
   ansible.builtin.service:

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -8,11 +8,11 @@
 
 - name: Include tasks for upgrade using redhat-upgrade-tool
   ansible.builtin.include_tasks: redhat-upgrade-tool-upgrade.yml
-  when: ansible_distribution_major_version|int == 6
+  when: ansible_facts["distribution_major_version"]|int == 6
 
 - name: Include tasks for leapp upgrade
   ansible.builtin.include_tasks: leapp-upgrade.yml
-  when: ansible_distribution_major_version|int >= 7
+  when: ansible_facts["distribution_major_version"]|int >= 7
 
 - name: Include post upgrade validation
   ansible.builtin.include_tasks: upgrade-validation.yml

--- a/roles/upgrade/tasks/redhat-upgrade-tool-post-upgrade.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-post-upgrade.yml
@@ -34,7 +34,7 @@
 - name: redhat-upgrade-tool-post-upgrade | Include grub2-upgrade.yml
   ansible.builtin.include_tasks: grub2-upgrade.yml
   when:
-    - ansible_architecture == 'x86_64'
+    - ansible_facts["architecture"] == 'x86_64'
     - leapp_update_grub_to_grub_2
 
 - name: redhat-upgrade-tool-post-upgrade | Include update-and-reboot.yml

--- a/roles/upgrade/tasks/upgrade-validation.yml
+++ b/roles/upgrade/tasks/upgrade-validation.yml
@@ -8,15 +8,17 @@
 
 - name: upgrade-validation | Validate current OS major version
   ansible.builtin.assert:
-    that: ansible_distribution_major_version == rhel_dest_major_version
-    fail_msg: Expected leapp destination OS major version {{ rhel_dest_major_version }} but OS major version is {{ ansible_distribution_major_version }}.
-    success_msg: Current OS version is {{ ansible_distribution_version }}.
+    that: ansible_facts["distribution_major_version"] == rhel_dest_major_version
+    fail_msg: >-
+      Expected leapp destination OS major version {{ rhel_dest_major_version }} but
+      OS major version is {{ ansible_facts['distribution_major_version'] }}.
+    success_msg: Current OS version is {{ ansible_facts['distribution_version'] }}.
 
 - name: upgrade-validation | Validate running kernel matches OS version
   ansible.builtin.assert:
-    that: "'el' ~ rhel_dest_major_version in ansible_kernel"
-    fail_msg: Kernel version {{ ansible_kernel }} does not match expected OS major version el{{ rhel_dest_major_version }}.
-    success_msg: Current kernel version is {{ ansible_kernel }}.
+    that: "'el' ~ rhel_dest_major_version in ansible_facts['kernel']"
+    fail_msg: Kernel version {{ ansible_facts['kernel'] }} does not match expected OS major version el{{ rhel_dest_major_version }}.
+    success_msg: Current kernel version is {{ ansible_facts['kernel'] }}.
 
 - name: upgrade-validation | Include leapp post upgrade validation
   ansible.builtin.include_tasks: leapp-upgrade-validation.yml

--- a/tests/tasks/setup/version_lock.yml
+++ b/tests/tasks/setup/version_lock.yml
@@ -1,7 +1,7 @@
 ---
 - name: setup | version_lock | Install versionlock module
   ansible.builtin.package:
-    name: "{{ 'yum-plugin-versionlock' if ansible_distribution_major_version | int == 7 else 'python3-dnf-plugin-versionlock' }}"
+    name: "{{ 'yum-plugin-versionlock' if ansible_facts['distribution_major_version'] | int == 7 else 'python3-dnf-plugin-versionlock' }}"
     state: present
 
 - name: setup | version_lock | Version lock the dracut package

--- a/tests/tasks/tests_upgrade_custom.yml
+++ b/tests/tasks/tests_upgrade_custom.yml
@@ -18,8 +18,8 @@
         tests_upgrade_custom | Skip test if already upgraded or not RHEL
         {{ rhel_base_ver }}
       when: >-
-          ansible_distribution not in ['CentOS', 'RedHat']
-          or ansible_distribution_major_version | int != rhel_base_ver
+          ansible_facts["distribution"] not in ['CentOS', 'RedHat']
+          or ansible_facts["distribution_major_version"] | int != rhel_base_ver
           or leapp_upgrade_completed is defined
           or leapp_log_stat.stat.exists
       ansible.builtin.meta: end_play
@@ -30,12 +30,12 @@
     - name: tests_upgrade_custom | Assert that the system has been upgraded
       ansible.builtin.assert:
         that:
-          - ansible_distribution in ['CentOS', 'RedHat']
-          - ansible_distribution_major_version | int == rhel_target_ver
+          - ansible_facts["distribution"] in ['CentOS', 'RedHat']
+          - ansible_facts["distribution_major_version"] | int == rhel_target_ver
         fail_msg: >-
           System was not upgraded to RHEL {{ rhel_target_ver }}.
-          Current OS: {{ ansible_distribution }}
-          {{ ansible_distribution_version }}
+          Current OS: {{ ansible_facts['distribution'] }}
+          {{ ansible_facts['distribution_version'] }}
         success_msg: >-
           System successfully upgraded to RHEL {{ rhel_target_ver }}
       when: leapp_test_upgrade | d(true)

--- a/tests/tasks/verify/postupgrade/version_lock.yml
+++ b/tests/tasks/verify/postupgrade/version_lock.yml
@@ -1,7 +1,7 @@
 ---
 - name: postupgrade | version_lock | Check if the versionlock module is still installed
   ansible.builtin.package:
-    name: "{{ 'yum-plugin-versionlock' if ansible_distribution_major_version | int == 7 else 'python3-dnf-plugin-versionlock' }}"
+    name: "{{ 'yum-plugin-versionlock' if ansible_facts['distribution_major_version'] | int == 7 else 'python3-dnf-plugin-versionlock' }}"
     state: present
 
 - name: postupgrade | version_lock | Check if the version lock on dracut package was cleared
@@ -25,5 +25,5 @@
       - package_info.stdout is search(pattern, multiline=true)
   vars:
     pattern: >-
-      ^Release\s*:\s*.*[.]el{{ ansible_distribution_major_version }}
+      ^Release\s*:\s*.*[.]el{{ ansible_facts['distribution_major_version'] }}
 ...


### PR DESCRIPTION
Ansible 2.20 has deprecated the use of Ansible facts as variables.  For
example, `ansible_distribution` is now deprecated in favor of
`ansible_facts["distribution"]`.  This is due to making the default
setting `INJECT_FACTS_AS_VARS=false`.  For now, this will create WARNING
messages, but in Ansible 2.24 it will be an error.

See https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.20.html#inject-facts-as-vars

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
