### PR TITLE
fix: check for leapp_inhibitors not defined

### DIFF
--- a/changelogs/fragments/fix-handle-leapp_inhibitors-not-defined.yml
+++ b/changelogs/fragments/fix-handle-leapp_inhibitors-not-defined.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - The leapp_inhibitors variable is sometimes not defined
+
+...

--- a/roles/analysis/tasks/main.yml
+++ b/roles/analysis/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Set stats for leapp_inhibitors
   ansible.builtin.set_stats:
     data:
-      leapp_inhibitors: "{{ leapp_inhibitors }}"
+      leapp_inhibitors: "{{ leapp_inhibitors | default([]) }}"
 
 - name: Notify analysis report is done handler
   ansible.builtin.assert:


### PR DESCRIPTION
If no inhibitors are found, `leapp_inhibitors` may be undefined.
