### PR TITLE
ci: use ANSIBLE_INJECT_FACT_VARS=false by default for testing

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -208,6 +208,7 @@ jobs:
             RHEL_9_LATEST_BASEOS_REPO_URL=${{ secrets.RHEL_9_LATEST_BASEOS_REPO_URL }};\
             RHEL_9_LATEST_APPSTREAM_REPO_URL=${{ secrets.RHEL_9_LATEST_APPSTREAM_REPO_URL }};\
             BEAKERLIB_HARNESS_URL_NO_VER=${{ secrets.BEAKERLIB_HARNESS_URL_NO_VER }};\
+            SR_ANSIBLE_INJECT_FACT_VARS=false;\
             SR_ARTIFACTS_URL=${{ steps.set_vars.outputs.ARTIFACTS_URL }}"
           tmt_context: "initiator=testing-farm"
           # Note that LINUXSYSTEMROLES_SSH_KEY must be single-line, TF doesn't read multi-line variables fine.

--- a/changelogs/fragments/338-ci-inject-facts-false-by-default.yml
+++ b/changelogs/fragments/338-ci-inject-facts-false-by-default.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Set SR_ANSIBLE_INJECT_FACT_VARS to false by default in the CI.
+
+...

--- a/tests/tmt/test_playbooks/test_playbooks.sh
+++ b/tests/tmt/test_playbooks/test_playbooks.sh
@@ -100,6 +100,14 @@ SR_RESERVE_SYSTEMS="${SR_RESERVE_SYSTEMS:-false}"
 #   TMT sets True, False with capital letters, need to reset it to bash style
 [ "$SR_RESERVE_SYSTEMS" = True ] && export SR_RESERVE_SYSTEMS=true
 [ "$SR_RESERVE_SYSTEMS" = False ] && export SR_RESERVE_SYSTEMS=false
+#
+# SR_ANSIBLE_INJECT_FACT_VARS
+#   Set to true if you want ansible to convert facts into vars like ansible_distribution
+#   This is deprecated in newer version of ansible and will be removed in 2.24
+SR_ANSIBLE_INJECT_FACT_VARS="${SR_ANSIBLE_INJECT_FACT_VARS:-false}"
+#   TMT sets True, False with capital letters, need to reset it to bash style
+[ "$SR_ANSIBLE_INJECT_FACT_VARS" = True ] && export SR_ANSIBLE_INJECT_FACT_VARS=true
+[ "$SR_ANSIBLE_INJECT_FACT_VARS" = False ] && export SR_ANSIBLE_INJECT_FACT_VARS=false
 
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "~~~ Environment Variables Definition - BEGIN"
@@ -162,6 +170,7 @@ rlJournalStart
         #     done
         # fi
         # lsrSetAnsibleGathering "$SR_ANSIBLE_GATHERING"
+        lsrSetAnsibleInjectFactVars "$SR_ANSIBLE_INJECT_FACT_VARS"
         lsrPrepareNodesInventories
         managed_nodes=$(lsrGetManagedNodes)
     rlPhaseEnd


### PR DESCRIPTION
Ansible 2.20 has deprecated the use of Ansible facts as variables.  For
example, `ansible_distribution` is now deprecated in favor of
`ansible_facts["distribution"]`.  This is due to making the default
setting `INJECT_FACTS_AS_VARS=false`.  For now, this will create WARNING
messages, but in Ansible 2.24 it will be an error.

In order to ensure that commits and PRs conform to this, use
ANSIBLE_INJECT_FACT_VARS=false by default in our CI testing.

See https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.20.html#inject-facts-as-vars

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
