### PR TITLE
fix removal of package version locks

### DIFF
--- a/changelogs/fragments/339-fix-version-lock-check.yml
+++ b/changelogs/fragments/339-fix-version-lock-check.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed task responsible for removing package version locks that would fail if versionlock sub-command for dnf/yum was not available.
+...

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -42,7 +42,7 @@
     cmd: "{{ ansible_facts['pkg_mgr'] }} versionlock clear"
   changed_when: true
   when:
-    - versionlock_list is success
+    - versionlock_list.rc == 0
     - versionlock_list.stdout | d("") != ""
 
 - name: leapp-upgrade | Install packages for upgrade from RHEL 7


### PR DESCRIPTION
Fixed task responsible for removing package version locks that would fail if versionlock sub-command for dnf/yum was not available.