### PR TITLE
add metalink support for custom local repos

### DIFF
--- a/changelogs/fragments/341-support-metalink.yml
+++ b/changelogs/fragments/341-support-metalink.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add support for metalink field in custom repository definitions.
+...

--- a/roles/common/tasks/custom_local_repos.yml
+++ b/roles/common/tasks/custom_local_repos.yml
@@ -6,11 +6,19 @@
   when:
     - __leapp_repo_file is defined
 
+- name: custom_local_repos | Validate repo definitions have baseurl or metalink
+  ansible.builtin.assert:
+    that:
+      - item.baseurl is defined or item.metalink is defined
+    fail_msg: "Custom repo '{{ item.repoid | default(item.name | default('unnamed')) }}' must define baseurl or metalink."
+  loop: "{{ __repos }}"
+
 - name: custom_local_repos | Enable custom upgrade yum repositories
   ansible.builtin.yum_repository:
     name: "{{ item.name }}"
     description: "{{ item.description }}"
-    baseurl: "{{ item.baseurl }}"
+    baseurl: "{{ item.baseurl | default(omit) }}"
+    metalink: "{{ item.metalink | default(omit) }}"
     enabled: "{{ item.enabled | default(1) }}"
     gpgcheck: "{{ item.gpgcheck | default(0) }}"
     gpgkey: "{{ item.gpgkey | default(omit) }}"
@@ -22,5 +30,4 @@
     mode: "0644"
   loop: "{{ __repos }}"
   # no_log: true
-
 ...


### PR DESCRIPTION
The custom repos supported only baseurl definition for the path to the content. This patch enables the metalink definition and enforces at least one to be defined. This will be required in future when support for CentOS upgrades will be added to the collection. 