### PR TITLE
fix: Add parameter leapp_remediate_ssh_password_auth with default value true

### DIFF
--- a/changelogs/fragments/268-allow-to-not-remediate-root-login.yml
+++ b/changelogs/fragments/268-allow-to-not-remediate-root-login.yml
@@ -1,0 +1,9 @@
+---
+bugfixes:
+  - Add parameter leapp_remediate_ssh_password_auth with default value true to remediate role.
+  - This parameter is used to determine whether to remediate SSH password authentication by setting PasswordAuthentication to no
+  - and PermitRootLogin to prohibit-password.
+  - By default, this is true, which is the old default.
+  - The default leapp_remediate_ssh_password_auth true might lock out your Ansible session and the play will
+  - fail if you are using Ansible with ssh and password authentication.
+...

--- a/roles/remediate/README.md
+++ b/roles/remediate/README.md
@@ -14,6 +14,10 @@ The `remediation` role is to assist in the remediation of a system. This role co
 | leapp_reboot_timeout          | 7200                  | Integer for maximum seconds to wait for reboot to complete.     |
 | leapp_pre_reboot_delay        | 60                    | Integer to pass to the reboot pre_reboot_delay option. |
 | leapp_post_reboot_delay       | 120                   | Integer to pass to the reboot post_reboot_delay option. |
+| leapp_remediate_ssh_password_auth | true              | Add "PasswordAuthentcation no" and "PermitRootLogin prohibit-password" to sshd config |
+
+NOTE: If you use password authentication for Ansible (`--user root --ask-pass`), then setting `leapp_remediate_ssh_password_auth: true`
+might lock out your Ansible session and the play will fail.
 
 `leapp_remediation_todo` is a list of remediation playbooks to run. The list is empty by default. The list can be populated by the titles from [Remediation playbooks](#remediation-playbooks) section. For example:
 

--- a/roles/remediate/defaults/main.yml
+++ b/roles/remediate/defaults/main.yml
@@ -26,4 +26,11 @@ leapp_remediation_playbooks: "{{ remediation_playbooks |
 # remediation_todo is deprecated, use leapp_remediation_todo instead
 # leapp_remediation_todo: []
 leapp_remediation_todo: "{{ remediation_todo | default([]) }}"
+
+# leapp_remediate_ssh_password_auth
+# Whether to remediate SSH password authentication by setting PasswordAuthentication to no
+# and PermitRootLogin to prohibit-password
+# by default this is true, which is the old default
+leapp_remediate_ssh_password_auth: true
+
 ...

--- a/roles/remediate/tasks/leapp_remote_using_root.yml
+++ b/roles/remediate/tasks/leapp_remote_using_root.yml
@@ -7,9 +7,11 @@
         regex: "^(#)?{{ item.key }}"
         line: "{{ item.key }} {{ item.value }}"
         state: present
-      loop:
-        - {key: "PermitRootLogin", value: "prohibit-password"}
-        - {key: "PasswordAuthentication", value: "no"}
+      loop: "{{ settings if leapp_remediate_ssh_password_auth else [] }}"
+      vars:
+        settings:
+          - {key: "PermitRootLogin", value: "prohibit-password"}
+          - {key: "PasswordAuthentication", value: "no"}
       notify:
         - Restart sshd
 

--- a/tests/tasks/setup/remediate_remote_using_root.yml
+++ b/tests/tasks/setup/remediate_remote_using_root.yml
@@ -1,0 +1,7 @@
+# set up the test system to test not remediating SSH password authentication
+---
+- name: setup | remediate_remote_using_root | Set the parameter to not remediate SSH password authentication
+  ansible.builtin.set_fact:
+    leapp_remediate_ssh_password_auth: false
+
+...

--- a/tests/tasks/verify/preupgrade/remediate_remote_using_root.yml
+++ b/tests/tasks/verify/preupgrade/remediate_remote_using_root.yml
@@ -1,0 +1,13 @@
+# verify the remote using root remediation
+# verify that the lines are present or absent depending on the value of leapp_remediate_ssh_password_auth
+---
+- name: preupgrade | remediate_remote_using_root | Verify the remote using root remediation
+  ansible.builtin.command: grep -E '^{{ item }}' /etc/ssh/sshd_config
+  changed_when: false
+  register: grep_sshd_config
+  failed_when: (leapp_remediate_ssh_password_auth and grep_sshd_config.rc != 0) or
+    (not leapp_remediate_ssh_password_auth and grep_sshd_config.rc == 0)
+  loop:
+    - PasswordAuthentication no
+    - PermitRootLogin prohibit-password
+...


### PR DESCRIPTION
Add parameter leapp_remediate_ssh_password_auth with default value false to remediate role.
This parameter is used to determine whether to remediate SSH password authentication by setting PasswordAuthentication to no
and PermitRootLogin to prohibit-password.
By default, this is true, which is the old default.
The default `leapp_remediate_ssh_password_auth: true` might lock out your Ansible session and the play will
fail if you are using Ansible with ssh and password authentication.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
