### PR TITLE
rename variables for satellite activation keys

### DIFF
--- a/changelogs/fragments/359-rename-satellite-activation-key-variables.yml
+++ b/changelogs/fragments/359-rename-satellite-activation-key-variables.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Renamed Satellite activation key variables for clarity. ``leapp_satellite_activation_key_leapp`` is now ``leapp_satellite_activation_key``, ``leapp_satellite_activation_key_pre_leapp`` is now ``leapp_satellite_activation_key_post_analysis``, and ``leapp_satellite_activation_key_post_leapp`` is now ``leapp_satellite_activation_key_post_upgrade``. The old variables are now deprecated.
+...

--- a/playbooks/analysis.yml
+++ b/playbooks/analysis.yml
@@ -7,9 +7,10 @@
   force_handlers: true
 
   vars:
+    leapp_upgrade_type: satellite
     leapp_satellite_organization: My Satellite Organization
-    leapp_satellite_activation_key_pre_leapp: MY_ACTIVATION_KEY_PRE
-    leapp_satellite_activation_key_leapp: MY_ACTIVATION_KEY
+    leapp_satellite_activation_key_post_analysis: MY_ACTIVATION_KEY_POST_ANALYSIS
+    leapp_satellite_activation_key: MY_ACTIVATION_KEY
     # By default the analysis role will use:
     # analysis_repos_el7: rhel-7-server-extras-rpms
     # Optionally override the default analysis_repos_el7 to use the upstream copr leapp repository:

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -5,9 +5,10 @@
   become: true
   force_handlers: true
   vars:
+    leapp_upgrade_type: satellite
     leapp_satellite_organization: My Satellite Organization
-    leapp_satellite_activation_key_leapp: MY_ACTIVATION_KEY
-    leapp_satellite_activation_key_post_leapp: MY_ACTIVATION_KEY_POST
+    leapp_satellite_activation_key: MY_ACTIVATION_KEY
+    leapp_satellite_activation_key_post_upgrade: MY_ACTIVATION_KEY_POST_UPGRADE
     leapp_upgrade_opts: --target 8.10
     leapp_update_grub_to_grub_2: true
     leapp_selinux_mode: permissive

--- a/roles/analysis/README.md
+++ b/roles/analysis/README.md
@@ -10,18 +10,18 @@ This role will not fail if there are inhibitors found, it will throw a warning. 
 
 | Name                  | Type | Default value           | Description                                     |
 |-----------------------|------|-------------------------|-------------------------------------------------|
-| leapp_upgrade_type    | String  | "satellite" | Set to "cdn" for hosts registered with Red Hat CDN, "rhui" for hosts using rhui repos, and "custom" for custom repos. |
+| leapp_upgrade_type    | String  | "cdn" | Set to "cdn" for hosts registered with Red Hat CDN, "rhui" for hosts using rhui repos, "satellite" for hosts registered to Satellite, and "custom" for custom repos. |
 
 ## Satellite variables
 
-Activation keys provide a method to identify content views available from Red Hat Satellite. To do in-place upgrades using Satellite, both the current RHEL version and the next RHEL version repositories must be available. Use these variables to specify the activation keys for the required content views. In case the system uses a different content view than the one used for the upgrade, one can specify the `leapp_satellite_activation_key_pre_leapp` in order to re-register to it after the analysis concludes, leaving the system in its original state. If not specified, the system will remain registered to the `leapp_satellite_activation_key_leapp` used during the analysis.
+Activation keys provide a method to identify content views available from Red Hat Satellite. To do in-place upgrades using Satellite, both the current RHEL version and the next RHEL version repositories must be available. Use these variables to specify the activation keys for the required content views. In case the system uses a different content view than the one used for the upgrade, one can specify the `leapp_satellite_activation_key_post_analysis` in order to register to it after the analysis concludes, leaving the system in its original state. If not specified, the system will remain registered to the `leapp_satellite_activation_key` used during the analysis.
 
 | Name                  | Type | Default value           | Description                                     |
 |-----------------------|------|-------------------------|-------------------------------------------------|
-| leapp_satellite_organization  | String   | "" | Organization used in Satellite definition |
-| leapp_satellite_activation_key_leapp     | String | "" | Activation key for the content view including both the current RHEL version and the next version |
-| leapp_satellite_activation_key_pre_leapp | String | leapp_satellite_activation_key_leapp | Activation key for the current RHEL version content view to re-register to after analysis |
-| leapp_repos_enabled    | List | [] | Satellite repo for the satellite client RPM install |
+| leapp_satellite_organization | String | "" | Organization used in Satellite definition |
+| leapp_satellite_activation_key | String | "" | Activation key for the content view including both the current RHEL version and the next version |
+| leapp_satellite_activation_key_post_analysis | String | leapp_satellite_activation_key | Activation key for the current RHEL version content view to register to after analysis |
+| leapp_repos_enabled | List | [] | Satellite repo for the satellite client RPM install |
 
 ## Custom repos variables
 

--- a/roles/analysis/defaults/main.yml
+++ b/roles/analysis/defaults/main.yml
@@ -56,8 +56,10 @@ leapp_preupg_opts: "{{ '--no-rhsm' if leapp_upgrade_type == 'rhui' or leapp_upgr
 # Satellite Organization and Activation Keys are required if using Satellite to change content views
 # unless the content view already in use has all required repositories.
 leapp_satellite_organization: ""
-leapp_satellite_activation_key_leapp: ""
-leapp_satellite_activation_key_pre_leapp: "{{ leapp_satellite_activation_key_leapp }}"
+# leapp_satellite_activation_key_leapp is deprecated, use leapp_satellite_activation_key instead
+leapp_satellite_activation_key: "{{ leapp_satellite_activation_key_leapp | default('') }}"
+# leapp_satellite_activation_key_pre_leapp is deprecated, use leapp_satellite_activation_key_post_analysis instead
+leapp_satellite_activation_key_post_analysis: "{{ leapp_satellite_activation_key_pre_leapp | default(leapp_satellite_activation_key) }}"
 
 # leapp_repos_enabled:
 #   - satellite-client-6-for-rhel-{{ ansible_facts['distribution_major_version'] | int + 1 }}-x86_64-rpms

--- a/roles/analysis/tasks/analysis-leapp.yml
+++ b/roles/analysis/tasks/analysis-leapp.yml
@@ -5,7 +5,7 @@
     tasks_from: register-satellite.yml
   vars:
     satellite_organization: "{{ leapp_satellite_organization }}"
-    satellite_activation_key: "{{ leapp_satellite_activation_key_leapp }}"
+    satellite_activation_key: "{{ leapp_satellite_activation_key }}"
   when: leapp_upgrade_type == 'satellite'
 
 - name: analysis-leapp | Include custom_local_repos for local_repos_pre_leapp
@@ -99,10 +99,10 @@
     tasks_from: register-satellite.yml
   vars:
     satellite_organization: "{{ leapp_satellite_organization }}"
-    satellite_activation_key: "{{ leapp_satellite_activation_key_pre_leapp }}"
+    satellite_activation_key: "{{ leapp_satellite_activation_key_post_analysis }}"
   when:
     - leapp_upgrade_type == 'satellite'
-    - leapp_satellite_activation_key_pre_leapp != leapp_satellite_activation_key_leapp
+    - leapp_satellite_activation_key_post_analysis != leapp_satellite_activation_key
 
 - name: analysis-leapp | Include check-results-file.yml
   ansible.builtin.include_tasks: check-results-file.yml

--- a/roles/analysis/tasks/analysis-preupg-el6.yml
+++ b/roles/analysis/tasks/analysis-preupg-el6.yml
@@ -13,7 +13,7 @@
     tasks_from: register-satellite-el6.yml
   vars:
     satellite_organization: "{{ leapp_satellite_organization }}"
-    satellite_activation_key: "{{ leapp_satellite_activation_key_leapp }}"
+    satellite_activation_key: "{{ leapp_satellite_activation_key }}"
   when: leapp_upgrade_type == 'satellite'
 
 - name: analysis-preupg-el6 | Include custom_local_repos for local_repos_pre_leapp
@@ -93,10 +93,10 @@
     tasks_from: register-satellite-el6.yml
   vars:
     satellite_organization: "{{ leapp_satellite_organization }}"
-    satellite_activation_key: "{{ leapp_satellite_activation_key_pre_leapp }}"
+    satellite_activation_key: "{{ leapp_satellite_activation_key_post_analysis }}"
   when:
     - leapp_upgrade_type == 'satellite'
-    - leapp_satellite_activation_key_pre_leapp != leapp_satellite_activation_key_leapp
+    - leapp_satellite_activation_key_post_analysis != leapp_satellite_activation_key
 
 - name: analysis-preupg-el6 | Include check-results-file.yml
   ansible.builtin.include_tasks: check-results-file.yml

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -8,7 +8,7 @@ Additionally a list of any non-Red Hat RPM packages that were installed on the s
 
 | Name                    | Default value         | Description                                         |
 |-------------------------|-----------------------|-----------------------------------------------------|
-| leapp_upgrade_type      | "satellite"           | Set to "cdn" for hosts registered with Red Hat CDN, "rhui" for hosts using rhui repos, and "custom" for custom repos. |
+| leapp_upgrade_type      | "cdn"           | Set to "cdn" for hosts registered with Red Hat CDN, "rhui" for hosts using rhui repos, "satellite" for hosts registered to Satellite, and "custom" for custom repos. |
 | leapp_upgrade_opts      |                       | Optional string to define command line options to be passed to the `leapp` command when running the upgrade. |
 | leapp_repos_enabled     |                       | Optional list of repos to limit for use in the upgrade process. |
 | leapp_selinux_mode            | same as before upgrade | Define this variable to the desired SELinux mode to be set after the OS upgrade, i.e., enforcing, permissive, or disabled. By default, the SELinux mode will be set to what was found during the pre-upgrade analysis. |
@@ -36,14 +36,14 @@ Additionally a list of any non-Red Hat RPM packages that were installed on the s
 
 ## Satellite variables
 
-Activation keys provide a method to identify content views available from Red Hat Satellite. To do in-place upgrades using Satellite, both the current RHEL version and the next RHEL version repositories must be available. Use these variables to specify the activation keys for the required content views. In case the system should be registered to a different activation key after the upgrade, one can specify the `leapp_satellite_activation_key_post_leapp` in order to re-register to it after the upgrade concludes. If not specified, the system will remain registered to the `leapp_satellite_activation_key_leapp` used during the upgrade.
+Activation keys provide a method to identify content views available from Red Hat Satellite. To do in-place upgrades using Satellite, both the current RHEL version and the next RHEL version repositories must be available. Use these variables to specify the activation keys for the required content views. In case the system should be registered to a different activation key after the upgrade, one can specify the `leapp_satellite_activation_key_post_upgrade` in order to register to it after the upgrade concludes. If not specified, the system will remain registered to the `leapp_satellite_activation_key` used during the upgrade.
 
 | Name                  | Type | Default value           | Description                                     |
 |-----------------------|------|-------------------------|-------------------------------------------------|
-| leapp_satellite_organization  | String   | "" | Organization used in Satellite definition |
-| leapp_satellite_activation_key_leapp     | String | "" | Activation key for the content view including both the current RHEL version and the next version |
-| leapp_satellite_activation_key_post_leapp     | String | leapp_satellite_activation_key_leapp | Activation key for the content view with the next RHEL version to register to after the upgrade |
-| leapp_repos_enabled    | List | [] | Satellite repo for the satellite client RPM install |
+| leapp_satellite_organization | String   | "" | Organization used in Satellite definition |
+| leapp_satellite_activation_key | String | "" | Activation key for the content view including both the current RHEL version and the next version |
+| leapp_satellite_activation_key_post_upgrade | String | leapp_satellite_activation_key | Activation key for the content view with the next RHEL version to register to after the upgrade |
+| leapp_repos_enabled | List | [] | Satellite repo for the satellite client RPM install |
 
 ## Custom repos variables
 

--- a/roles/upgrade/defaults/main.yml
+++ b/roles/upgrade/defaults/main.yml
@@ -46,8 +46,10 @@ leapp_rhel_7_network_install_repo_url: "{{ rhel_7_network_install_repo_url | def
 # Satellite Organization and Activation Keys are required if using Satellite to change content views
 # unless the content view already in use has all required repositories.
 leapp_satellite_organization: ""
-leapp_satellite_activation_key_leapp: ""
-leapp_satellite_activation_key_post_leapp: "{{ leapp_satellite_activation_key_leapp }}"
+# leapp_satellite_activation_key_leapp is deprecated, use leapp_satellite_activation instead
+leapp_satellite_activation_key: "{{ leapp_satellite_activation_key_leapp | default('') }}"
+# leapp_satellite_activation_key_post_leapp is deprecated, use leapp_satellite_activation_key_post_upgrade instead
+leapp_satellite_activation_key_post_upgrade: "{{ leapp_satellite_activation_key_post_leapp | default(leapp_satellite_activation_key) }}"
 
 # For leapp_upgrade_type == "custom"
 # Used to configure repos before running leapp analysis / installing leapp packages.

--- a/roles/upgrade/tasks/leapp-post-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade.yml
@@ -132,10 +132,10 @@
     tasks_from: register-satellite.yml
   vars:
     satellite_organization: "{{ leapp_satellite_organization }}"
-    satellite_activation_key: "{{ leapp_satellite_activation_key_post_leapp }}"
+    satellite_activation_key: "{{ leapp_satellite_activation_key_post_upgrade }}"
   when:
     - leapp_upgrade_type == 'satellite'
-    - leapp_satellite_activation_key_post_leapp != leapp_satellite_activation_key_leapp
+    - leapp_satellite_activation_key_post_upgrade != leapp_satellite_activation_key
 
 - name: leapp-post-upgrade | Include custom_local_repos for local_repos_post_upgrade
   vars:

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -17,7 +17,7 @@
     tasks_from: register-satellite.yml
   vars:
     satellite_organization: "{{ leapp_satellite_organization }}"
-    satellite_activation_key: "{{ leapp_satellite_activation_key_leapp }}"
+    satellite_activation_key: "{{ leapp_satellite_activation_key }}"
   when: leapp_upgrade_type == 'satellite'
 
 - name: leapp-upgrade | Include custom_local_repos for local_repos_pre_leapp

--- a/roles/upgrade/tasks/redhat-upgrade-tool-post-upgrade-el6.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-post-upgrade-el6.yml
@@ -10,10 +10,10 @@
     tasks_from: register-satellite-el6.yml
   vars:
     satellite_organization: "{{ leapp_satellite_organization }}"
-    satellite_activation_key: "{{ leapp_satellite_activation_key_post_leapp }}"
+    satellite_activation_key: "{{ leapp_satellite_activation_key_post_upgrade }}"
   when:
     - leapp_upgrade_type == 'satellite'
-    - leapp_satellite_activation_key_post_leapp != leapp_satellite_activation_key_leapp
+    - leapp_satellite_activation_key_post_upgrade != leapp_satellite_activation_key
 
 - name: redhat-upgrade-tool-post-upgrade-el6 | Include custom_local_repos for local_repos_post_upgrade
   vars:

--- a/roles/upgrade/tasks/redhat-upgrade-tool-upgrade-el6.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-upgrade-el6.yml
@@ -28,7 +28,7 @@
     tasks_from: register-satellite-el6.yml
   vars:
     satellite_organization: "{{ leapp_satellite_organization }}"
-    satellite_activation_key: "{{ leapp_satellite_activation_key_leapp }}"
+    satellite_activation_key: "{{ leapp_satellite_activation_key }}"
   when: leapp_upgrade_type == 'satellite'
 
 - name: redhat-upgrade-tool-upgrade-el6 | Include custom_local_repos for local_repos_post_upgrade


### PR DESCRIPTION
Renamed variables that specify activation keys used by the collection to register the system during different phases of the upgrade.

`leapp_satellite_activation_key_leapp` -> `leapp_satellite_activation_key`
`leapp_satellite_activation_key_pre_leapp` -> `leapp_satellite_activation_key_post_analysis` `leapp_satellite_activation_key_post_leapp` -> `leapp_satellite_activation_key_post_upgrade`

This patch also updates the readmes and example playbooks relevant to this change and fixes the default value of `leapp_upgrade_type` variable in the readme as well.