### PR TITLE
Update readme tables

### DIFF
--- a/changelogs/fragments/360-unify-tables-in-readmes.yml
+++ b/changelogs/fragments/360-unify-tables-in-readmes.yml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - Unified tables in role READMEs for consistent formatting.
+...

--- a/roles/analysis/README.md
+++ b/roles/analysis/README.md
@@ -8,45 +8,45 @@ This role will not fail if there are inhibitors found, it will throw a warning. 
 
 ## Role variables
 
-| Name                  | Type | Default value           | Description                                     |
-|-----------------------|------|-------------------------|-------------------------------------------------|
-| leapp_upgrade_type    | String  | "cdn" | Set to "cdn" for hosts registered with Red Hat CDN, "rhui" for hosts using rhui repos, "satellite" for hosts registered to Satellite, and "custom" for custom repos. |
+| Name               | Type   | Default value | Description |
+|--------------------|--------|---------------|-------------|
+| leapp_upgrade_type | String | "cdn"         | Set to "cdn" for hosts registered with Red Hat CDN, "rhui" for hosts using rhui repos, "satellite" for hosts registered to Satellite, and "custom" for custom repos. |
 
 ## Satellite variables
 
 Activation keys provide a method to identify content views available from Red Hat Satellite. To do in-place upgrades using Satellite, both the current RHEL version and the next RHEL version repositories must be available. Use these variables to specify the activation keys for the required content views. In case the system uses a different content view than the one used for the upgrade, one can specify the `leapp_satellite_activation_key_post_analysis` in order to register to it after the analysis concludes, leaving the system in its original state. If not specified, the system will remain registered to the `leapp_satellite_activation_key` used during the analysis.
 
-| Name                  | Type | Default value           | Description                                     |
-|-----------------------|------|-------------------------|-------------------------------------------------|
-| leapp_satellite_organization | String | "" | Organization used in Satellite definition |
-| leapp_satellite_activation_key | String | "" | Activation key for the content view including both the current RHEL version and the next version |
-| leapp_satellite_activation_key_post_analysis | String | leapp_satellite_activation_key | Activation key for the current RHEL version content view to register to after analysis |
-| leapp_repos_enabled | List | [] | Satellite repo for the satellite client RPM install |
+| Name                                         | Type   | Default value                  | Description |
+|----------------------------------------------|--------|--------------------------------|-------------|
+| leapp_satellite_organization                 | String | ""                             | Organization used in Satellite definition. |
+| leapp_satellite_activation_key               | String | ""                             | Activation key for the content view including both the current RHEL version and the next version. |
+| leapp_satellite_activation_key_post_analysis | String | leapp_satellite_activation_key | Activation key for the current RHEL version content view to register to after analysis. |
+| leapp_repos_enabled                          | List   | []                             | Satellite repo for the satellite client RPM install. |
 
 ## Custom repos variables
 
 See comments in defaults/main.yml for additional details.
 
-| Name                  | Type | Default value           | Description                                     |
-|-----------------------|------|-------------------------|-------------------------------------------------|
-| leapp_local_repos_pre  | List of dicts   | [] | Used to configure repos before running leapp analysis / installing leapp packages.|
-| leapp_local_repos  | List of dicts   | [] | Used to configure next version repos in /etc/leapp/files/leapp_upgrade_repositories.repo. |
-| leapp_local_repos_post_analysis  | List of dicts   | [] | Used to return repos to previous state after leapp analysis if necessary. |
+| Name                            | Type          | Default value | Description |
+|---------------------------------|---------------|---------------|-------------|
+| leapp_local_repos_pre           | List of dicts | []            | Used to configure repos before running leapp analysis / installing leapp packages. |
+| leapp_local_repos               | List of dicts | []            | Used to configure next version repos in /etc/leapp/files/leapp_upgrade_repositories.repo. |
+| leapp_local_repos_post_analysis | List of dicts | []            | Used to return repos to previous state after leapp analysis if necessary. |
 
 ## Optional variables
 
-| Name                  | Type | Default value           | Description                                     |
-|-----------------------|------|-------------------------|-------------------------------------------------|
-| leapp_answerfile | Multi-line String |  | If defined, this is written to `/var/log/leapp/answerfile` before generating the pre-upgrade report. |
-| leapp_preupg_opts | String | | Optional string to define command line options to be passed to the `leapp` command when running the pre-upgrade. |
-| leapp_high_sev_as_inhibitors | Boolean | False | Treat all high severity findings as inhibitors. |
-| leapp_known_inhibitors | List | [] | List of keys of known inhibitors ignored when setting upgrade_inhibited and leapp_inhibitors. |
-| leapp_env_vars | Dict | {} | Environment variables to use when running `leapp` command. See defaults/main.yml for example. |
-| leapp_os_path | String | $PATH | Option string to override the $PATH variable used on the target node |
-| leapp_async_timeout_maximum   | Int | 7200                  | Variable used to set the asynchronous task timeout value (in seconds) |
-| leapp_async_poll_interval     | Int | 60                    | Variable used to set the asynchronous task polling internal value (in seconds) |
-| leapp_bypass_fs_checks | Boolean | false | Set to `true` to bypass filesystem capacity checks |
-| leapp_system_roles_collection | String | fedora.linux_system_roles | Set which Ansible Collection to use for System Roles. For community/upstream, use 'fedora.linux_system_roles'. For the RHEL, AAP, use 'redhat.rhel_system_roles'. |
+| Name                                        | Type              | Default value               | Description |
+|---------------------------------------------|-------------------|-----------------------------|-------------|
+| leapp_answerfile                            | Multi-line String | ""                          | If defined, this is written to `/var/log/leapp/answerfile` before generating the pre-upgrade report. |
+| leapp_preupg_opts                           | String            | ""                          | Optional string to define command line options to be passed to the `leapp` command when running the pre-upgrade. |
+| leapp_high_sev_as_inhibitors                | Boolean           | false                       | Treat all high severity findings as inhibitors. |
+| leapp_known_inhibitors                      | List              | []                          | List of keys of known inhibitors ignored when setting upgrade_inhibited and leapp_inhibitors. |
+| leapp_env_vars                              | Dict              | {}                          | Environment variables to use when running `leapp` command. See defaults/main.yml for example. |
+| leapp_os_path                               | String            | $PATH                       | Option string to override the $PATH variable used on the target node. |
+| leapp_async_timeout_maximum                 | Int               | 7200                        | Variable used to set the asynchronous task timeout value (in seconds). |
+| leapp_async_poll_interval                   | Int               | 60                          | Variable used to set the asynchronous task polling internal value (in seconds). |
+| leapp_bypass_fs_checks                      | Boolean           | false                       | Set to `true` to bypass filesystem capacity checks. |
+| leapp_infra_upgrade_system_roles_collection | String            | "fedora.linux_system_roles" | Set which Ansible Collection to use for System Roles. For community/upstream, use 'fedora.linux_system_roles'. For the RHEL, AAP, use 'redhat.rhel_system_roles'. |
 
 ## Example playbook
 

--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -14,36 +14,36 @@ Define job_name in the import as seen below.
 
 ## Role variables
 
-| Name                  | Type | Optional | Default value | Description |
-|-----------------------|------|----------|---------------|-------------------------------------------------|
-| job_name | String | No | None | The string describes the job run |
-| leapp_log_directory | DirPath | Yes | "/var/log/ripu" | Directory under which local log files will be written. This directory will be created is it is not already present |
-| leapp_log_file | FilePath | Yes | "{{ leapp_log_directory }}/ripu.log" | Local log filename. When a playbook job finishes, a timestamp suffix is appended to the end of the specified filename |
+| Name                | Type   | Default value                               | Description |
+|---------------------|--------|---------------------------------------------|-------------|
+| job_name            | String |                                             | The string describes the job run. This variable is required. |
+| leapp_log_directory | String | "/var/log/ripu"                             | Directory under which local log files will be written. This directory will be created if it is not already present. |
+| leapp_log_file      | String | "{{ leapp_log_directory }}/ripu.log"        | Local log filename. When a playbook job finishes, a timestamp suffix is appended to the end of the specified filename. |
 
 ### Role variables used with parse_leapp_report.yml
 
 **NOTE:** `leapp_result_filename` is **REQUIRED**.  The other leapp_result_filename* parameters will be derived from it if not explicitly given.
 
-| Name                         | Type   | Default value                     | Description                                                                      |
-|------------------------------|--------|-----------------------------------|----------------------------------------------------------------------------------|
-| leapp_result_filename              | string | /var/log/leapp/leapp-report.txt   | REQUIRED - Path of the Leapp pre-upgrade report file.                            |
-| leapp_result_filename_prefix       | string | /var/log/leapp/leapp-report       | The path used and the prefix name setting for the Leapp report                   |
-| leapp_result_filename_json         | string | {{ leapp_result_filename_prefix }}.json | JSON filename using the selected "leapp_result_filename_prefix"                        |
-| leapp_result_fact_cacheable        | bool   | false                             | Allow the results from parsing the LEAPP report be cacheable (primarily for AAP) |
-| leapp_high_sev_as_inhibitors | bool   | false                             | Treat all high severity findings as inhibitors.                                  |
+| Name                         | Type    | Default value                                 | Description |
+|------------------------------|---------|-----------------------------------------------|-------------|
+| leapp_result_filename        | String  | "/var/log/leapp/leapp-report.txt"             | REQUIRED - Path of the Leapp pre-upgrade report file. |
+| leapp_result_filename_prefix | String  | "/var/log/leapp/leapp-report"                 | The path used and the prefix name setting for the Leapp report. |
+| leapp_result_filename_json   | String  | "{{ leapp_result_filename_prefix }}.json"     | JSON filename using the selected "leapp_result_filename_prefix". |
+| leapp_result_fact_cacheable  | Boolean | false                                         | Allow the results from parsing the LEAPP report be cacheable (primarily for AAP). |
+| leapp_high_sev_as_inhibitors | Boolean | false                                         | Treat all high severity findings as inhibitors. |
 
 ### Variables exported by parse_leapp_report.yml
 
 `register` means it is the result of a `command` written to a `register` variable and so has `rc`, `stdout`, etc.
 
-| Name               | Type     | Description                                            |
-|--------------------|----------|--------------------------------------------------------|
-| leapp_report_txt   | list     | List of lines from the text report                     |
-| leapp_report_json  | dict     | The JSON report returned as a dict object              |
-| leapp_inhibitors   | list     | Raw list of inhibitors                                 |
-| results_inhibitors | register | Result of parsing out inhibitors from leapp_result_filename  |
-| results_errors     | register | Result of parsing out high errors from leapp_result_filename |
-| upgrade_inhibited  | bool     | true if there are inhibitors blocking upgrade          |
+| Name               | Type     | Description |
+|--------------------|----------|-------------|
+| leapp_report_txt   | List     | List of lines from the text report. |
+| leapp_report_json  | Dict     | The JSON report returned as a dict object. |
+| leapp_inhibitors   | List     | Raw list of inhibitors. |
+| results_inhibitors | Register | Result of parsing out inhibitors from leapp_result_filename. |
+| results_errors     | Register | Result of parsing out high errors from leapp_result_filename. |
+| upgrade_inhibited  | Boolean  | true if there are inhibitors blocking upgrade. |
 
 ### How to use parse_leapp_report.yml
 

--- a/roles/remediate/README.md
+++ b/roles/remediate/README.md
@@ -6,19 +6,19 @@ The `remediation` role is to assist in the remediation of a system. This role co
 
 ## Role variables
 
-| Name                    | Default value         | Description                                         |
-|-------------------------|-----------------------|-----------------------------------------------------|
-| leapp_report_location   | /var/log/leapp/leapp-report.json | Location of the leapp report file.       |
-| leapp_remediation_playbooks   | see [Remediation playbooks](#remediation-playbooks) | List of available remediation playbooks.|
-| leapp_remediation_todo        | []                    | List of remediation playbooks to run.               |
-| leapp_reboot_timeout          | 7200                  | Integer for maximum seconds to wait for reboot to complete.     |
-| leapp_pre_reboot_delay        | 60                    | Integer to pass to the reboot pre_reboot_delay option. |
-| leapp_post_reboot_delay       | 120                   | Integer to pass to the reboot post_reboot_delay option. |
-| leapp_remediate_ssh_password_auth | true              | Add "PasswordAuthentcation no" and "PermitRootLogin prohibit-password" to sshd config |
+| Name                              | Type    | Default value                                       | Description |
+|-----------------------------------|---------|-----------------------------------------------------|-------------|
+| leapp_report_location             | String  | "/var/log/leapp/leapp-report.json"                  | Location of the leapp report file. |
+| leapp_remediation_playbooks       | List    | see [Remediation playbooks](#remediation-playbooks) | List of available remediation playbooks. |
+| leapp_remediation_todo            | List    | []                                                  | List of remediation playbooks to run. |
+| leapp_reboot_timeout              | Int     | 7200                                                | Integer for maximum seconds to wait for reboot to complete. |
+| leapp_pre_reboot_delay            | Int     | 60                                                  | Integer to pass to the reboot pre_reboot_delay option. |
+| leapp_post_reboot_delay           | Int     | 120                                                 | Integer to pass to the reboot post_reboot_delay option. |
+| leapp_remediate_ssh_password_auth | Boolean | true                                                | Add "PasswordAuthentcation no" and "PermitRootLogin prohibit-password" to sshd config |
+| leapp_system_roles_collection     | String  | "fedora.linux_system_roles"                         | Set which Ansible Collection to use for System Roles. For community/upstream, use "fedora.linux_system_roles". For the RHEL, AAP, use "redhat.rhel_system_roles". |
 
 NOTE: If you use password authentication for Ansible (`--user root --ask-pass`), then setting `leapp_remediate_ssh_password_auth: true`
 might lock out your Ansible session and the play will fail.
-| leapp_system_roles_collection | fedora.linux_system_roles | Set which Ansible Collection to use for System Roles. For community/upstream, use 'fedora.linux_system_roles'. For the RHEL, AAP, use 'redhat.rhel_system_roles'. |
 
 `leapp_remediation_todo` is a list of remediation playbooks to run. The list is empty by default. The list can be populated by the titles from [Remediation playbooks](#remediation-playbooks) section. For example:
 

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -6,56 +6,56 @@ Additionally a list of any non-Red Hat RPM packages that were installed on the s
 
 ## Role variables
 
-| Name                    | Default value         | Description                                         |
-|-------------------------|-----------------------|-----------------------------------------------------|
-| leapp_upgrade_type      | "cdn"           | Set to "cdn" for hosts registered with Red Hat CDN, "rhui" for hosts using rhui repos, "satellite" for hosts registered to Satellite, and "custom" for custom repos. |
-| leapp_upgrade_opts      |                       | Optional string to define command line options to be passed to the `leapp` command when running the upgrade. |
-| leapp_repos_enabled     |                       | Optional list of repos to limit for use in the upgrade process. |
-| leapp_selinux_mode            | same as before upgrade | Define this variable to the desired SELinux mode to be set after the OS upgrade, i.e., enforcing, permissive, or disabled. By default, the SELinux mode will be set to what was found during the pre-upgrade analysis. |
-| leapp_set_crypto_policies     | true                  | Boolean to define if system-wide cryptographic policies should be set after the OS upgrade |
-| leapp_crypto_policy           | "DEFAULT"             | System-wide cryptographic to set, e.g., "FUTURE", "DEFAULT:SHA1", etc. Refer to the crypto-policies (7) man page for more information. |
-| leapp_reboot_timeout          | 7200                  | Integer for maximum seconds to wait for reboot to complete. |
-| leapp_upgrade_timeout         | 14400                 | Integer for maximum seconds to wait for reboot to complete during upgrade reboot. |
-| leapp_post_reboot_delay       | 120                   | Integer to pass to the reboot post_reboot_delay option. |
-| leapp_resume_retries    | 360                   | Integer for maximum retries to wait for leapp_resume service no longer exists. |
-| leapp_resume_delay      | 10                    | Integer for seconds between each attempt to check leapp_resume service no longer exists. |
-| leapp_update_grub_to_grub_2   | false                 | Boolean to control whether grub gets upgraded to grub 2 in post RHEL 6 to 7 upgrade. |
-| leapp_os_path                 | $PATH                 | Variable used to override the default $PATH environmental variable on the target node. |
-| leapp_async_timeout_maximum   | 7200                  | Variable used to set the asynchronous task timeout value (in seconds) |
-| leapp_async_poll_interval     | 60                    | Variable used to set the asynchronous task polling internal value (in seconds) |
-| leapp_check_analysis_results| true              | Allows for running remediation and going straight to upgrade without re-running analysis. |
-| leapp_pre_upgrade_update      | true                  | Boolean to decide if an update and reboot on the running pre-upgrade operating system will run. |
-| leapp_post_upgrade_update     | true                   | Boolean to decide if after the upgrade is performed a dnf update will run. |
-| leapp_post_upgrade_unset_release| true                | Boolean used to control whether Leapp's RHSM release lock is unset. |
-| leapp_post_upgrade_release    |                       | Optional string used to set a specific RHSM release lock after the Leapp upgrade, but before the final update pass. |
-| leapp_kernel_modules_to_unload_before_upgrade | []    | A list of kernel modules to be unloaded prior to running leapp. |
-| leapp_post_upgrade_python_interpreter | /usr/libexec/platform-python | Set interpreter used by Ansible after the upgrade to execute post-upgrade tasks. Usually you do not need to change this variable because the default value is the system-level python interpreter that is always present. |
-| leapp_system_roles_collection | fedora.linux_system_roles | Set which Ansible Collection to use for System Roles. For community/upstream, use 'fedora.linux_system_roles'. For the RHEL, AAP, use 'redhat.rhel_system_roles'. |
-| leapp_remove_old_rhel_packages | true                 | Boolean to control whether the previous version RHEL packages should be removed. Change to false to maintain behavior of infra.leapp prior to  release 1.6.0. |
-| leapp_grub_boot_device | null | Optional device path (e.g., /dev/sda) for grub2-install. If not defined, will be auto-detected from /boot or / mount point. |
+| Name                                          | Type    | Default value                  | Description |
+|-----------------------------------------------|---------|--------------------------------|-------------|
+| leapp_upgrade_type                            | String  | "cdn"                          | Set to "cdn" for hosts registered with Red Hat CDN, "rhui" for hosts using rhui repos, "satellite" for hosts registered to Satellite, and "custom" for custom repos. |
+| leapp_upgrade_opts                            | String  | ""                             | Optional string to define command line options to be passed to the `leapp` command when running the upgrade. |
+| leapp_repos_enabled                           | List    | []                             | Optional list of repos to limit for use in the upgrade process. |
+| leapp_selinux_mode                            | String  | same as before upgrade         | Define this variable to the desired SELinux mode to be set after the OS upgrade, i.e., enforcing, permissive, or disabled. By default, the SELinux mode will be set to what was found during the pre-upgrade analysis. |
+| leapp_set_crypto_policies                     | Boolean | true                           | Boolean to define if system-wide cryptographic policies should be set after the OS upgrade. |
+| leapp_crypto_policy                           | String  | "DEFAULT"                      | System-wide cryptographic to set, e.g., "FUTURE", "DEFAULT:SHA1", etc. Refer to the crypto-policies (7) man page for more information. |
+| leapp_reboot_timeout                          | Int     | 7200                           | Integer for maximum seconds to wait for reboot to complete. |
+| leapp_upgrade_timeout                         | Int     | 14400                          | Integer for maximum seconds to wait for reboot to complete during upgrade reboot. |
+| leapp_post_reboot_delay                       | Int     | 120                            | Integer to pass to the reboot post_reboot_delay option. |
+| leapp_resume_retries                          | Int     | 360                            | Integer for maximum retries to wait for leapp_resume service no longer exists. |
+| leapp_resume_delay                            | Int     | 10                             | Integer for seconds between each attempt to check leapp_resume service no longer exists. |
+| leapp_update_grub_to_grub_2                   | Boolean | false                          | Boolean to control whether grub gets upgraded to grub 2 in post RHEL 6 to 7 upgrade. |
+| leapp_os_path                                 | String  | $PATH                          | Variable used to override the default $PATH environmental variable on the target node. |
+| leapp_async_timeout_maximum                   | Int     | 7200                           | Variable used to set the asynchronous task timeout value (in seconds). |
+| leapp_async_poll_interval                     | Int     | 60                             | Variable used to set the asynchronous task polling internal value (in seconds). |
+| leapp_check_analysis_results                  | Boolean | true                           | Allows for running remediation and going straight to upgrade without re-running analysis. |
+| leapp_pre_upgrade_update                      | Boolean | true                           | Boolean to decide if an update and reboot on the running pre-upgrade operating system will run. |
+| leapp_post_upgrade_update                     | Boolean | true                           | Boolean to decide if after the upgrade is performed a dnf update will run. |
+| leapp_post_upgrade_unset_release              | Boolean | true                           | Boolean used to control whether Leapp's RHSM release lock is unset. |
+| leapp_post_upgrade_release                    | String  | ""                             | Optional string used to set a specific RHSM release lock after the Leapp upgrade, but before the final update pass. |
+| leapp_kernel_modules_to_unload_before_upgrade | List    | []                             | A list of kernel modules to be unloaded prior to running leapp. |
+| leapp_post_upgrade_python_interpreter         | String  | "/usr/libexec/platform-python" | Set interpreter used by Ansible after the upgrade to execute post-upgrade tasks. Usually you do not need to change this variable because the default value is the system-level python interpreter that is always present. |
+| leapp_system_roles_collection                 | String  | "fedora.linux_system_roles" | Set which Ansible Collection to use for System Roles. For community/upstream, use "fedora.linux_system_roles". For the RHEL, AAP, use "redhat.rhel_system_roles". |
+| leapp_remove_old_rhel_packages                | Boolean | true                           | Boolean to control whether the previous version RHEL packages should be removed. Change to false to maintain behavior of infra.leapp prior to release 1.6.0. |
+| leapp_grub_boot_device                        | String  | null                           | Optional device path (e.g., /dev/sda) for grub2-install. If not defined, will be auto-detected from /boot or / mount point. |
 
 ## Satellite variables
 
 Activation keys provide a method to identify content views available from Red Hat Satellite. To do in-place upgrades using Satellite, both the current RHEL version and the next RHEL version repositories must be available. Use these variables to specify the activation keys for the required content views. In case the system should be registered to a different activation key after the upgrade, one can specify the `leapp_satellite_activation_key_post_upgrade` in order to register to it after the upgrade concludes. If not specified, the system will remain registered to the `leapp_satellite_activation_key` used during the upgrade.
 
-| Name                  | Type | Default value           | Description                                     |
-|-----------------------|------|-------------------------|-------------------------------------------------|
-| leapp_satellite_organization | String   | "" | Organization used in Satellite definition |
-| leapp_satellite_activation_key | String | "" | Activation key for the content view including both the current RHEL version and the next version |
-| leapp_satellite_activation_key_post_upgrade | String | leapp_satellite_activation_key | Activation key for the content view with the next RHEL version to register to after the upgrade |
-| leapp_repos_enabled | List | [] | Satellite repo for the satellite client RPM install |
+| Name                                        | Type   | Default value                  | Description |
+|---------------------------------------------|--------|--------------------------------|-------------|
+| leapp_satellite_organization                | String | ""                             | Organization used in Satellite definition. |
+| leapp_satellite_activation_key              | String | ""                             | Activation key for the content view including both the current RHEL version and the next version. |
+| leapp_satellite_activation_key_post_upgrade | String | leapp_satellite_activation_key | Activation key for the content view with the next RHEL version to register to after the upgrade. |
+| leapp_repos_enabled                         | List   | []                             | Satellite repo for the satellite client RPM install. |
 
 ## Custom repos variables
 
 See comments in defaults/main.yml for additional details.
 
-| Name                  | Type | Default value           | Description                                     |
-|-----------------------|------|-------------------------|-------------------------------------------------|
-| leapp_local_repos_pre  | List of dicts   | [] | Used to configure repos for yum update before running leapp upgrade (current version).|
-| leapp_local_repos  | List of dicts   | [] | Used to configure next version repos in /etc/leapp/files/leapp_upgrade_repositories.repo.
-| leapp_local_repos_post_upgrade  | List of dicts   | [] | Used to configure next version repos post upgrade (can be set to leapp_local_repos if the same)
-| leapp_repo_files_to_remove_at_upgrade  | List   | [] | Simpler way to remove /etc/yum.repos.d files before leapp upgrade is run.
-| leapp_env_vars | Dict | {} | Environment variables to use when running `leapp` command. See defaults/main.yml for example. |
+| Name                                  | Type          | Default value | Description |
+|---------------------------------------|---------------|---------------|-------------|
+| leapp_local_repos_pre                 | List of dicts | []            | Used to configure repos for yum update before running leapp upgrade (current version). |
+| leapp_local_repos                     | List of dicts | []            | Used to configure next version repos in /etc/leapp/files/leapp_upgrade_repositories.repo. |
+| leapp_local_repos_post_upgrade        | List of dicts | []            | Used to configure next version repos post upgrade (can be set to leapp_local_repos if the same). |
+| leapp_repo_files_to_remove_at_upgrade | List          | []            | Simpler way to remove /etc/yum.repos.d files before leapp upgrade is run. |
+| leapp_env_vars                        | Dict          | {}            | Environment variables to use when running `leapp` command. See defaults/main.yml for example. |
 
 ## Example playbook
 


### PR DESCRIPTION
The format of tables in READMEs that containing collection variables was
inconsistent and hard to read. This patch unifies the tables by adding
the expected type to every variable and makes the types and values
consistent. Better spacing was also added to improve readability in raw
format.

Issue #355.