### PR TITLE
ci: add Ansible partner certification check

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -22,14 +22,6 @@ exclude_paths:
 # strict: true
 # verbosity: 1
 
-# Mock modules or roles in order to pass ansible-playbook --syntax-check
-# Mocking these modules so they do not give errors due to the galaxy importer
-# not being able to pull community.general (not being validated)
-mock_modules:
-  - fedora.linux_system_roles.rhc
-  - fedora.linux_system_roles.selinux
-  - fedora.linux_system_roles.storage
-
 # mock_roles:
 #   - mocked_role
 #   - author.role_name # old standalone galaxy role

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -1,0 +1,46 @@
+---
+# This workflow calls the latest version of the
+# reusable workflow.
+# You can copy this file into your respository if
+# you want to check against pinned versions of
+# Automation Hub tests.
+name: Run collection certification checks
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+concurrency:
+  group: cert-ver-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+
+# Files that are not related to the core functionality
+# of your collection can cause Ansible Lint to fail.
+# If this happens, add an .ansible-lint file that includes
+# those files and directories to the root of your
+# repository; for example:
+# https://github.com/ansible-collections/partner-certification-checker/blob/main/.ansible-lint
+# https://github.com/ansible-collections/partner-certification-checker/blob/main/.ansible-lint
+
+# If there are sanity test failures that cannot be fixed and are allowed to ignore
+# https://docs.ansible.com/projects/lint/rules/sanity/, create a sanity ignore file
+# https://docs.ansible.com/projects/ansible/devel/dev_guide/testing/sanity/ignores.html#ignore-file-location
+# for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
+jobs:
+  call:
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@2f6d9300ebe9190da3120a740c3a4d5ca2f0f02e # v1.0.0
+    # If the minimal Ansible Core version your collection supports Ansible
+    # is greater than 2.16.0, specify it below.
+    # You might also have to specify Python version supported by that version,
+    # see https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
+    # with:
+    #   ansible-core-version: '2.17.0'
+    #   python-versions: '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'
+    #   collection-root: 'ansible_collections/junipernetworks/junos'

--- a/changelogs/fragments/ci-use-ansible-partner-cert-checker.yml
+++ b/changelogs/fragments/ci-use-ansible-partner-cert-checker.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Use the ansible-collections/partner-certification-checker collection for CI.
+
+...

--- a/tests/tmt/test_playbooks/test_playbooks.sh
+++ b/tests/tmt/test_playbooks/test_playbooks.sh
@@ -85,6 +85,7 @@ SR_ANSIBLE_GATHERING="${SR_ANSIBLE_GATHERING:-implicit}"
 SR_REQUIRED_VARS=("SR_ANSIBLE_VER")
 # SR_ANSIBLE_VERBOSITY
 #   Default is "-vv" - user can locally edit tft.yml in role to increase this for debugging
+# shellcheck disable=SC2153
 [ -n "$LSR_ANSIBLE_VERBOSITY" ] && export SR_ANSIBLE_VERBOSITY="$LSR_ANSIBLE_VERBOSITY"
 SR_ANSIBLE_VERBOSITY="${SR_ANSIBLE_VERBOSITY:--vv}"
 # SR_REPORT_ERRORS_URL


### PR DESCRIPTION
https://github.com/ansible-collections/partner-certification-checker/blob/main/README.md

This checks that the collection can be imported into Automation Hub, among other
things.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
