### PR TITLE
feat: add role fingerprints to syslog

### DIFF
--- a/changelogs/fragments/feat-role-fingerprints-in-syslog.yml
+++ b/changelogs/fragments/feat-role-fingerprints-in-syslog.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Log role fingerprints in syslog.
+
+...

--- a/plugins/modules/sr_fingerprint.py
+++ b/plugins/modules/sr_fingerprint.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: sr_fingerprint
+short_description: Write a message string to syslog using Ansible C(module.log) function.
+description:
+    - Writes the given string to the system log using Ansible C(module.log) function.
+    - Intended for role-internal or diagnostic use.
+author: Rich Megginson (@richm)
+options:
+    sr_message:
+        description: Text to record in syslog.
+        type: str
+        required: true
+"""
+
+EXAMPLES = """
+- name: Record a fingerprint message in syslog
+  sr_fingerprint:
+    sr_message: "system_role:ROLENAME"
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+
+import datetime
+
+
+def _local_iso8601_no_microseconds():
+    """System local wall clock with local tz offset, ISO 8601, seconds only."""
+    try:
+        utc = datetime.timezone.utc
+    except AttributeError:
+        import time
+
+        return time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime())
+    # Prefer the local clock interpreted in the system timezone (not UTC displayed).
+    now = datetime.datetime.now()
+    astimezone = getattr(now, "astimezone", None)
+    if astimezone is not None:
+        try:
+            return astimezone().replace(microsecond=0).isoformat()
+        except (OSError, TypeError, ValueError):
+            pass
+    return datetime.datetime.now(utc).astimezone().replace(microsecond=0).isoformat()
+
+
+def run_module():
+    module_args = dict(
+        sr_message=dict(type="str", required=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    log_message = "%s %s" % (
+        module.params["sr_message"],
+        _local_iso8601_no_microseconds(),
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=False,
+            message="Check mode: message not logged - [%s]" % log_message,
+        )
+
+    module.log(log_message)
+
+    # we don't actually change anything, so we're not changed - writing a log message
+    # is not considered a change
+    # also, we don't want to report changed every time the role runs
+    module.exit_json(changed=False)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/analysis/tasks/main.yml
+++ b/roles/analysis/tasks/main.yml
@@ -7,6 +7,12 @@
     __leapp_role_required_facts: "{{ __leapp_analysis_required_facts }}"
     __leapp_role_required_facts_subsets: "{{ __leapp_analysis_required_facts_subsets }}"
 
+- name: Record role begin fingerprint
+  infra.leapp.sr_fingerprint:
+    sr_message: >-
+      begin infra.leapp:analysis ansible_version={{ ansible_version.full }}
+      {{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}
+
 # If we store timestamp variable in vars, it  is processed dynamically at
 # runtime, hence timestamp changes on each variable invocation. We want the
 # timestamp to be stable so that logs are stored in the same directory.
@@ -43,4 +49,10 @@
     quiet: true
   changed_when: true
   notify: Preupgrade analysis report is done
+
+- name: Record role success fingerprint
+  infra.leapp.sr_fingerprint:
+    sr_message: >-
+      success infra.leapp:analysis ansible_version={{ ansible_version.full }}
+      {{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}
 ...

--- a/roles/analysis/tests/tests_default.yml
+++ b/roles/analysis/tests/tests_default.yml
@@ -4,11 +4,36 @@
   vars:
     job_name: test_analysis
   tasks:
+    - name: See if /dev/log exists for the fingerprint check
+      ansible.builtin.stat:
+        path: /dev/log
+      register: __register_dev_log
+
+    - name: Set the start time for the journal search
+      ansible.builtin.set_fact:
+        __journal_start_time: "{{ ansible_facts['date_time']['date'] ~ ' ' ~ ansible_facts['date_time']['time'] }}"
+      when: __register_dev_log.stat.exists
+
     - name: Test | Run analysis
       block:
         - name: Test | Run role analysis
           ansible.builtin.include_role:
             name: infra.leapp.analysis
+
+        # look for the exact module invocation, not some other message that might contain the string
+        - name: Check system journal contains role fingerprints
+          ansible.builtin.shell:
+            executable: /bin/bash
+            cmd: >-
+              set -eo pipefail;
+              journalctl --since "{{ __journal_start_time }}" --no-pager |
+              grep -v " Invoked with" | grep "sr_fingerprint.*begin infra.leapp:analysis" ||
+              { echo ERROR: BEGIN fingerprint not found; exit 1; };
+              journalctl --since "{{ __journal_start_time }}" --no-pager |
+              grep -v " Invoked with" | grep "sr_fingerprint.*success infra.leapp:analysis" ||
+              { echo ERROR: SUCCESS fingerprint not found; exit 1; }
+          changed_when: false
+          when: __register_dev_log.stat.exists
       always:
         - name: Test | Include cleanup logs
           ansible.builtin.include_role:

--- a/roles/remediate/tasks/main.yml
+++ b/roles/remediate/tasks/main.yml
@@ -8,6 +8,12 @@
     __leapp_role_required_facts: "{{ __leapp_remediate_required_facts }}"
     __leapp_role_required_facts_subsets: "{{ __leapp_remediate_required_facts_subsets }}"
 
+- name: Record role begin fingerprint
+  infra.leapp.sr_fingerprint:
+    sr_message: >-
+      begin infra.leapp:remediate ansible_version={{ ansible_version.full }}
+      {{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}
+
 - name: Run remediations
   vars:
     leapp_report_location_6to7: /root/preupgrade/result.txt
@@ -54,4 +60,10 @@
       loop: "{{ leapp_remediation_playbooks | intersect(leapp_remediation_todo) }}"
       loop_control:
         loop_var: remediation_item
+
+- name: Record role success fingerprint
+  infra.leapp.sr_fingerprint:
+    sr_message: >-
+      success infra.leapp:remediate ansible_version={{ ansible_version.full }}
+      {{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}
 ...

--- a/roles/remediate/tests/tests_default.yml
+++ b/roles/remediate/tests/tests_default.yml
@@ -5,6 +5,30 @@
   hosts: all
   vars:
     job_name: test_remediate
+  pre_tasks:
+    - name: See if /dev/log exists for the fingerprint check
+      ansible.builtin.stat:
+        path: /dev/log
+      register: __register_dev_log
+
+    - name: Set the start time for the journal search
+      ansible.builtin.set_fact:
+        __journal_start_time: "{{ ansible_facts['date_time']['date'] ~ ' ' ~ ansible_facts['date_time']['time'] }}"
+      when: __register_dev_log.stat.exists
   roles:
     - remediate
+  post_tasks:
+    - name: Check system journal contains role fingerprints
+      ansible.builtin.shell:
+        executable: /bin/bash
+        cmd: >-
+          set -eo pipefail;
+          journalctl --since "{{ __journal_start_time }}" --no-pager |
+          grep -v " Invoked with" | grep "sr_fingerprint.*begin infra.leapp:remediate" ||
+          { echo ERROR: BEGIN fingerprint not found; exit 1; };
+          journalctl --since "{{ __journal_start_time }}" --no-pager |
+          grep -v " Invoked with" | grep "sr_fingerprint.*success infra.leapp:remediate" ||
+          { echo ERROR: SUCCESS fingerprint not found; exit 1; }
+      changed_when: false
+      when: __register_dev_log.stat.exists
 ...

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -7,6 +7,12 @@
     __leapp_role_required_facts: "{{ __leapp_upgrade_required_facts }}"
     __leapp_role_required_facts_subsets: "{{ __leapp_upgrade_required_facts_subsets }}"
 
+- name: Record role begin fingerprint
+  infra.leapp.sr_fingerprint:
+    sr_message: >-
+      begin infra.leapp:upgrade ansible_version={{ ansible_version.full }}
+      {{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}
+
 # If we store timestamp variable in vars, it  is processed dynamically at
 # runtime, hence timestamp changes on each variable invocation. We want the
 # timestamp to be stable so that logs are stored in the same directory.
@@ -70,4 +76,10 @@
     quiet: true
   changed_when: true
   notify: Ansible leapp in-place OS upgrade is done
+
+- name: Record role success fingerprint
+  infra.leapp.sr_fingerprint:
+    sr_message: >-
+      success infra.leapp:upgrade ansible_version={{ ansible_version.full }}
+      {{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}
 ...

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.22.txt
+++ b/tests/sanity/ignore-2.22.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
Feature: Add a fingerprint string to the system log to indicate when the role began
successfully, and when the role finished successfully.  The fingerprint string indicates
the role name, a timestamp, and the platform.

Reason: Users can see when the role was used and if it was used successfully.  This
information from the system log can be collected by log scanners and aggregators
for further analysis.

Result: The role logs fingerprints to the system log.

This also adds a test to check if the fingerprints were written upon a successful
role invocation.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
