### PR TITLE
ci: Fix release workflow

### DIFF
--- a/.github/workflows/generate-changelog-and-release.yml
+++ b/.github/workflows/generate-changelog-and-release.yml
@@ -43,10 +43,13 @@ jobs:
             exit 1
           fi
 
+      # Avoid persisting checkout credentials: create-pull-request configures its own
+      # auth; both together cause Git to send duplicate Authorization headers (HTTP 400).
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
+          persist-credentials: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sync default branch and tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
             --title "infra.leapp ${VERSION}" \
             --notes-file CHANGELOG.rst \
             --verify-tag \
-            --attach "${{ steps.build.outputs.tar_file }}"
+            "${{ steps.build.outputs.tar_file }}"
 
       - name: Publish to Ansible Galaxy
         run: ansible-galaxy collection publish --api-key=${{ secrets.GALAXY_INFRA_KEY }} ${{ steps.build.outputs.tar_file }}


### PR DESCRIPTION
The --attach flag is not supported in the version of gh CLI available in GitHub Actions runners. Pass the tarball as a positional argument instead.
The checkout action and create-pull-request both configure auth, causing duplicate Authorization headers (HTTP 400 error).