### PR TITLE
chore: Add verbosity-based logging to reduce verbose output

### DIFF
--- a/.github/workflows/generate-changelog-and-release.yml
+++ b/.github/workflows/generate-changelog-and-release.yml
@@ -112,7 +112,7 @@ jobs:
           args: "--offline"
 
       - name: Open pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'Update changelog ${{ inputs.version }}'

--- a/changelogs/fragments/add-verbosity-based-logging.yml
+++ b/changelogs/fragments/add-verbosity-based-logging.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Add verbosity-based logging to reduce verbose output from slurp and set_fact tasks. Output is now suppressed by default but can be shown when running with -vvv or higher verbosity.
+
+...

--- a/roles/common/tasks/copy_archive_leapp_log.yml
+++ b/roles/common/tasks/copy_archive_leapp_log.yml
@@ -31,12 +31,12 @@
       ansible.builtin.slurp:
         src: "{{ leapp_log_file }}"
       register: leapp_log_file_slurp
-      no_log: true
+      no_log: "{{ ansible_verbosity < 3 }}"
 
     - name: copy_archive_leapp_log | Decode file {{ leapp_log_file }}
       ansible.builtin.set_fact:
         leapp_log_file_content: "{{ (leapp_log_file_slurp.content | b64decode).split('\n') }}"
-      no_log: true
+      no_log: "{{ ansible_verbosity < 3 }}"
 
     - name: copy_archive_leapp_log | Ensure reports directory on controller
       ansible.builtin.file:

--- a/roles/common/tasks/parse_leapp_report.yml
+++ b/roles/common/tasks/parse_leapp_report.yml
@@ -27,20 +27,20 @@
       ansible.builtin.slurp:
         src: "{{ leapp_result_filename }}"
       register: results_txt
-      no_log: true
+      no_log: "{{ ansible_verbosity < 3 }}"
 
     - name: parse_leapp_report | Collect JSON report results
       ansible.builtin.slurp:
         src: "{{ leapp_result_filename_json }}"
       register: results_json
-      no_log: true
+      no_log: "{{ ansible_verbosity < 3 }}"
 
     - name: parse_leapp_report | Parse report results
       ansible.builtin.set_fact:
         cacheable: "{{ leapp_result_fact_cacheable }}"
         leapp_report_txt: "{{ (results_txt.content | b64decode).split('\n') | list }}"
         leapp_report_json: "{{ results_json.content | b64decode | from_json }}"
-      no_log: true
+      no_log: "{{ ansible_verbosity < 3 }}"
 
     - name: parse_leapp_report | Clear leapp_inhibitors
       ansible.builtin.set_fact:

--- a/tests/tests_hostvars.yml
+++ b/tests/tests_hostvars.yml
@@ -88,7 +88,7 @@
           ansible.builtin.slurp:
             src: "{{ leapp_hostvars_file }}"
           register: hostvars_file_content
-          no_log: true
+          no_log: "{{ ansible_verbosity < 3 }}"
 
     - name: Test | Run role analysis
       ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
@@ -105,7 +105,7 @@
           ansible.builtin.slurp:
             src: "{{ leapp_hostvars_file }}"
           register: hostvars_file_new_content
-          no_log: true
+          no_log: "{{ ansible_verbosity < 3 }}"
 
         - name: Test | Assert that hostvars file contains remediation_todo
           ansible.builtin.assert:


### PR DESCRIPTION
Enhancement: Add verbosity-based logging using `no_log: "{{ ansible_verbosity < 3 }}"` to reduce verbose output from file slurping and fact setting tasks.

Reason: Tasks using slurp and set_fact with large file contents can produce verbose output that clutters logs during normal playbook execution. This output is useful for debugging but creates noise in standard runs.

Result: By using `ansible_verbosity < 3`, the output from these tasks is suppressed by default but can be shown when running with `-vvv` or higher verbosity for debugging purposes. This improves log readability while maintaining full debugging capabilities when needed.

Changes:
- `roles/common/tasks/parse_leapp_report.yml`: Updated slurp and set_fact tasks
- `roles/common/tasks/copy_archive_leapp_log.yml`: Updated slurp and set_fact tasks
- `tests/tests_hostvars.yml`: Updated test slurp tasks

Note: This is for verbosity control, not for security purposes - there's no sensitive information being hidden, just reducing noise in normal operation.